### PR TITLE
fix(compat): align SDK with platform contracts (closes #44, #46, #47, #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
-## [1.5.1] — 2026-04-06
+## [Unreleased]
 
 ### Security
 - **HTTP request timeouts** — added `timeout(30s)` and `connect_timeout(10s)` to `reqwest::Client::builder()` to prevent indefinite hangs on unresponsive servers (closes #24)
 - **Disable automatic redirects** — set `redirect(Policy::none())` on the HTTP client to prevent the Bearer token from being forwarded to third-party hosts via 3xx redirects (closes #25)
 - **Webhook secret skip_serializing** — added `#[serde(skip_serializing)]` to `Webhook.secret` field to prevent the HMAC signing secret from leaking via `serde_json::to_string()` or any serialization path; regression of #8 where only `Debug` was fixed but `Serialize` was missed (closes #43)
+
+### Fixed
+- **Issue #50**: `ai_query()` now sends `{ "question": ... }` instead of `{ "query": ... }` to match the platform's `AiQueryDto` contract — every call was previously rejected or silently ignored by the backend
+- **Issue #46**: `TradingMode` enum now serializes to `"LIVE"` / `"PAPER"` (uppercase) instead of `"live"` / `"paper"` — `start_strategy()` was receiving a 422 from the backend due to failed enum validation
+- **Issue #47**: `WebhookEvent` variants now serialize to dot-notation strings (`"order.filled"`, `"strategy.error"`, `"whale.trade"`, `"news.signal"`, `"backtest.complete"`, `"daily.loss.limit"`, `"market.resolved"`, `"price.alert"`) instead of `SCREAMING_SNAKE_CASE` — webhooks registered via the SDK were using invalid event type strings
+- **Issue #44**: `create_strategy_from_description()` now sends `{ "query": ... }` instead of `{ "description": ... }` to match the platform's `from-description` endpoint contract — the AI pipeline was receiving no input and returning empty/default strategies
 
 ## [1.5.0] — 2026-04-03
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -385,7 +385,7 @@ impl PolyforgeClient {
         description: &str,
         market_id: Option<&str>,
     ) -> Result<Strategy> {
-        let mut body = json!({ "description": description });
+        let mut body = json!({ "query": description });
         if let Some(mid) = market_id {
             body["marketId"] = json!(mid);
         }
@@ -772,7 +772,7 @@ impl PolyforgeClient {
 
     /// Send a natural-language query to the AI assistant.
     pub async fn ai_query(&self, query: &str) -> Result<AiQueryResponse> {
-        let body = json!({ "query": query });
+        let body = json!({ "question": query });
         self.post("/api/v1/ai/query", &body).await
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -85,9 +85,10 @@ pub enum StrategyStatus {
 
 /// Trading mode used when starting a strategy.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
 pub enum TradingMode {
+    #[serde(rename = "LIVE")]
     Live,
+    #[serde(rename = "PAPER")]
     Paper,
 }
 
@@ -370,15 +371,22 @@ pub struct CopyConfig {
 
 /// Webhook event types.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum WebhookEvent {
+    #[serde(rename = "order.filled")]
     OrderFilled,
+    #[serde(rename = "strategy.error")]
     StrategyError,
+    #[serde(rename = "whale.trade")]
     WhaleTrade,
+    #[serde(rename = "news.signal")]
     NewsSignal,
+    #[serde(rename = "backtest.complete")]
     BacktestComplete,
+    #[serde(rename = "daily.loss.limit")]
     DailyLossLimit,
+    #[serde(rename = "market.resolved")]
     MarketResolved,
+    #[serde(rename = "price.alert")]
     PriceAlert,
 }
 


### PR DESCRIPTION
## What changed

- `ai_query()`: sends `question` instead of `query` to match AiQueryDto (#50)
- `create_strategy_from_description()`: sends `query` instead of `description` (#44)
- `TradingMode`: serializes to uppercase `LIVE`/`PAPER` (#46)
- `WebhookEvent`: serializes to dot.notation instead of SCREAMING_SNAKE_CASE (#47)

## Quality gates
- `cargo check` ✅

closes #44, closes #46, closes #47, closes #50