### PR TITLE
fix(compat): handle 204 No Content, rename intervalMinutes to intervalSeconds (closes #66, closes #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - **Issue #46**: `TradingMode` enum now serializes to `"LIVE"` / `"PAPER"` (uppercase) instead of `"live"` / `"paper"` — `start_strategy()` was receiving a 422 from the backend due to failed enum validation
 - **Issue #47**: `WebhookEvent` variants now serialize to dot-notation strings (`"order.filled"`, `"strategy.error"`, `"whale.trade"`, `"news.signal"`, `"backtest.complete"`, `"daily.loss.limit"`, `"market.resolved"`, `"price.alert"`) instead of `SCREAMING_SNAKE_CASE` — webhooks registered via the SDK were using invalid event type strings
 - **Issue #44**: `create_strategy_from_description()` now sends `{ "query": ... }` instead of `{ "description": ... }` to match the platform's `from-description` endpoint contract — the AI pipeline was receiving no input and returning empty/default strategies
+- **BREAKING** `handle_response()`: handle 204 No Content by returning `serde_json::Value::Null` instead of crashing on empty body — `delete_strategy()` now returns `Result<()>` (closes #70)
+- **BREAKING** `PlaceSmartOrderParams`: rename `interval_minutes` / `"intervalMinutes"` to `interval_seconds` / `"intervalSeconds"` to match platform contract — TWAP/DCA orders were executing 60x too fast (closes #66)
 
 ## [1.5.0] — 2026-04-03
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -295,6 +295,10 @@ impl PolyforgeClient {
                     .map(String::from),
             });
         }
+        if status == 204 {
+            return serde_json::from_value(serde_json::Value::Null)
+                .map_err(PolyforgeError::from);
+        }
         let body = resp.text().await?;
         serde_json::from_str(&body).map_err(PolyforgeError::from)
     }
@@ -442,10 +446,11 @@ impl PolyforgeClient {
             .await
     }
 
-    /// Delete a strategy by ID.
-    pub async fn delete_strategy(&self, id: &str) -> Result<serde_json::Value> {
-        self.delete(&format!("/api/v1/strategies/{}", encode(id)))
-            .await
+    /// Delete a strategy by ID. Returns `()` on success (platform returns 204 No Content).
+    pub async fn delete_strategy(&self, id: &str) -> Result<()> {
+        self.delete::<serde_json::Value>(&format!("/api/v1/strategies/{}", encode(id)))
+            .await?;
+        Ok(())
     }
 
     /// Import a strategy from a .polyforge JSON export.

--- a/src/types.rs
+++ b/src/types.rs
@@ -507,8 +507,8 @@ pub struct PlaceSmartOrderParams {
     // TWAP / DCA
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slices: Option<u32>,
-    #[serde(rename = "intervalMinutes", skip_serializing_if = "Option::is_none")]
-    pub interval_minutes: Option<u32>,
+    #[serde(rename = "intervalSeconds", skip_serializing_if = "Option::is_none")]
+    pub interval_seconds: Option<u32>,
     #[serde(rename = "limitPrice", skip_serializing_if = "Option::is_none")]
     pub limit_price: Option<f64>,
     // BRACKET


### PR DESCRIPTION
## What changed

- **#70 — 204 No Content crash**: `handle_response()` now returns `Value::Null` on 204 instead of crashing with serde deserialization error. `delete_strategy()` return type changed to `Result<()>`.
- **#66 — intervalMinutes → intervalSeconds**: `PlaceSmartOrderParams.interval_minutes` renamed to `interval_seconds` and serde rename changed from `"intervalMinutes"` to `"intervalSeconds"` to match platform contract. TWAP/DCA orders were executing 60x too fast.

## Quality gates

- `cargo check` ✅

closes #66
closes #70