### PR TITLE
fix(security): enforce Clippy CI gate and correct README HTTPS default (closes #78, closes #79)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
 
       - name: Clippy
         run: cargo clippy -- -D warnings
-        continue-on-error: true
 
       - name: Build
         run: cargo build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Security
+- **Clippy CI gate enforced** — removed `continue-on-error: true` from Clippy step so lint warnings (including security-relevant ones) now block CI; fixed `map_or` → `is_some_and` clippy warning (closes #79)
+- **README documents HTTPS default** — corrected `http://` to `https://` in API reference table to match the actual `DEFAULT_BASE_URL` in code (closes #78)
 - **HTTP request timeouts** — added `timeout(30s)` and `connect_timeout(10s)` to `reqwest::Client::builder()` to prevent indefinite hangs on unresponsive servers (closes #24)
 - **Disable automatic redirects** — set `redirect(Policy::none())` on the HTTP client to prevent the Bearer token from being forwarded to third-party hosts via 3xx redirects (closes #25)
 - **Webhook secret skip_serializing** — added `#[serde(skip_serializing)]` to `Webhook.secret` field to prevent the HMAC signing secret from leaking via `serde_json::to_string()` or any serialization path; regression of #8 where only `Debug` was fixed but `Serialize` was missed (closes #43)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ async fn main() -> polyforge::Result<()> {
 
 | Method | Description |
 |--------|-------------|
-| `PolyforgeClient::new(api_key)` | Connect to `http://localhost:3002` |
+| `PolyforgeClient::new(api_key)` | Connect to `https://localhost:3002` |
 | `PolyforgeClient::with_url(api_key, url)` | Connect to a custom URL |
 
 ### Markets

--- a/src/client.rs
+++ b/src/client.rs
@@ -756,7 +756,7 @@ impl PolyforgeClient {
                         // link-local fe80::/10
                         || (v6.octets()[0] == 0xfe && (v6.octets()[1] & 0xc0) == 0x80)
                         // IPv4-mapped ::ffff:x.x.x.x — check the mapped IPv4
-                        || v6.to_ipv4_mapped().map_or(false, |v4| {
+                        || v6.to_ipv4_mapped().is_some_and(|v4| {
                             v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified()
                         })
                 }


### PR DESCRIPTION
## Problem

1. **#79**: Clippy CI step had `continue-on-error: true`, meaning security-relevant lint warnings never blocked PR merges
2. **#78**: README documented `http://localhost:3002` as default while code correctly uses `https://localhost:3002`

## What changed

- Removed `continue-on-error: true` from Clippy CI step
- Fixed `map_or` → `is_some_and` clippy warning in SSRF IPv4-mapped validation
- Corrected README API reference from `http://` to `https://`

## Quality gates

- `cargo clippy -- -D warnings` ✅ (0 warnings)
- `cargo build` ✅
- `cargo test` ✅ (25 unit + 2 doc-tests)

closes #78
closes #79