### PR TITLE
fix(compat): revert intervalSeconds back to intervalMinutes (closes #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Webhook secret skip_serializing** — added `#[serde(skip_serializing)]` to `Webhook.secret` field to prevent the HMAC signing secret from leaking via `serde_json::to_string()` or any serialization path; regression of #8 where only `Debug` was fixed but `Serialize` was missed (closes #43)
 
 ### Fixed
+- **BREAKING** `PlaceSmartOrderParams`: revert `interval_seconds`/`"intervalSeconds"` back to `interval_minutes`/`"intervalMinutes"` — the #66 fix was based on incorrect platform contract info; platform DTO uses `intervalMinutes` (closes #80)
 - **Issue #50**: `ai_query()` now sends `{ "question": ... }` instead of `{ "query": ... }` to match the platform's `AiQueryDto` contract — every call was previously rejected or silently ignored by the backend
 - **Issue #46**: `TradingMode` enum now serializes to `"LIVE"` / `"PAPER"` (uppercase) instead of `"live"` / `"paper"` — `start_strategy()` was receiving a 422 from the backend due to failed enum validation
 - **Issue #47**: `WebhookEvent` variants now serialize to dot-notation strings (`"order.filled"`, `"strategy.error"`, `"whale.trade"`, `"news.signal"`, `"backtest.complete"`, `"daily.loss.limit"`, `"market.resolved"`, `"price.alert"`) instead of `SCREAMING_SNAKE_CASE` — webhooks registered via the SDK were using invalid event type strings

--- a/src/types.rs
+++ b/src/types.rs
@@ -507,8 +507,8 @@ pub struct PlaceSmartOrderParams {
     // TWAP / DCA
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slices: Option<u32>,
-    #[serde(rename = "intervalSeconds", skip_serializing_if = "Option::is_none")]
-    pub interval_seconds: Option<u32>,
+    #[serde(rename = "intervalMinutes", skip_serializing_if = "Option::is_none")]
+    pub interval_minutes: Option<u32>,
     #[serde(rename = "limitPrice", skip_serializing_if = "Option::is_none")]
     pub limit_price: Option<f64>,
     // BRACKET


### PR DESCRIPTION
## Summary

- **#80**: `PlaceSmartOrderParams` was serializing `intervalSeconds` but platform expects `intervalMinutes`
- Regression from #66 which incorrectly renamed the field
- TWAP/DCA orders were silently losing interval config (NestJS `whitelist: true` strips unknown fields)

## What Changed

| File | Change |
|------|--------|
| `src/types.rs` | `interval_seconds` → `interval_minutes`, serde rename `intervalSeconds` → `intervalMinutes` |
| `CHANGELOG.md` | Documented the revert |

## Verification

- Platform DTO confirmed: `intervalMinutes` at `services/api-service/src/orders/dto/place-smart-order.dto.ts:51`
- TS SDK already correctly uses `intervalMinutes`
- All 27 tests pass, cargo build clean

closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)