### PR TITLE
fix(ci): switch to ubuntu-latest and restrict GITHUB_TOKEN (closes #72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Build, Lint & Test
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Security
+- **CI**: switch from self-hosted runner to `ubuntu-latest` for all events and add `permissions: contents: read` to restrict GITHUB_TOKEN scope — mitigates supply chain risk from external PRs running on self-hosted infra (closes #72)
 - **Clippy CI gate enforced** — removed `continue-on-error: true` from Clippy step so lint warnings (including security-relevant ones) now block CI; fixed `map_or` → `is_some_and` clippy warning (closes #79)
 - **README documents HTTPS default** — corrected `http://` to `https://` in API reference table to match the actual `DEFAULT_BASE_URL` in code (closes #78)
 - **HTTP request timeouts** — added `timeout(30s)` and `connect_timeout(10s)` to `reqwest::Client::builder()` to prevent indefinite hangs on unresponsive servers (closes #24)


### PR DESCRIPTION
## Summary
- Replace `self-hosted` runner with `ubuntu-latest` — prevents external PRs from executing code on self-hosted infrastructure
- Add `permissions: contents: read` to restrict GITHUB_TOKEN scope
- Removes supply chain risk from pull_request-triggered workflows

## Test plan
- [x] Workflow syntax valid (YAML lint)
- [ ] CI runs on PR (ubuntu-latest will compile and test)

closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)