### PR TITLE
fix(security): update default base URL from localhost to production (closes #87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Security
+- **Default URL updated to production** — changed `DEFAULT_BASE_URL` from `https://localhost:3002` to `https://api.polyforge.app` to match Python and TypeScript SDKs; localhost with HTTPS causes immediate TLS failures for new users and encourages insecure workarounds (closes #87, regression of #71)
 - **SSE buffer overflow protection** — `StrategyEventStream` now enforces a 1 MiB (`MAX_SSE_BUFFER_SIZE`) cap on its internal line buffer; if the server sends data without a newline beyond this limit the stream returns `PolyforgeError::Api` with code `SSE_BUFFER_OVERFLOW` instead of growing unboundedly toward OOM (closes #52)
 - **Cargo.lock committed for reproducible builds** — removed `Cargo.lock` from `.gitignore` and committed the lockfile so that `cargo audit` can run, builds are reproducible, and supply-chain attacks are detectable via dependency pinning (closes #42)
 - **DNS rebinding SSRF mitigation** — `validate_webhook_url()` now resolves domain names via `tokio::net::lookup_host()` and checks all resolved IPs against the private/loopback blocklist, preventing SSRF bypass via attacker-controlled DNS records; also adds CGNAT range (100.64.0.0/10, RFC 6598) to the blocklist; documents that this is a client-side best-effort check and the server must independently validate (closes #63, closes #41)

--- a/src/client.rs
+++ b/src/client.rs
@@ -101,7 +101,7 @@ impl StrategyEventStream {
     }
 }
 
-const DEFAULT_BASE_URL: &str = "https://localhost:3002";
+const DEFAULT_BASE_URL: &str = "https://api.polyforge.app";
 
 /// Async client for the Polyforge trading platform REST API.
 pub struct PolyforgeClient {
@@ -121,7 +121,7 @@ impl std::fmt::Debug for PolyforgeClient {
 
 impl PolyforgeClient {
     /// Create a new client using the `POLYFORGE_API_URL` environment variable,
-    /// falling back to the default local URL (`https://localhost:3002`).
+    /// falling back to the production API URL (`https://api.polyforge.app`).
     ///
     /// # Errors
     /// Returns [`PolyforgeError::Http`] if the underlying HTTP client fails to build.
@@ -948,7 +948,7 @@ mod tests {
     fn test_client_url_construction() {
         let client = PolyforgeClient::new("test-api-key").unwrap();
         let url = client.url("/api/v1/markets");
-        assert_eq!(url, "https://localhost:3002/api/v1/markets");
+        assert_eq!(url, "https://api.polyforge.app/api/v1/markets");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Updated `DEFAULT_BASE_URL` from `https://localhost:3002` to `https://api.polyforge.app`
- Matches Python and TypeScript SDK defaults
- Prevents TLS failures on first use and discourages insecure workarounds

## Problem
The Rust SDK's default URL still pointed to `https://localhost:3002` while the other SDKs were already updated to production. This caused immediate TLS errors for new users since localhost rarely has valid TLS certs, encouraging them to disable certificate verification.

## Test plan
- [x] All 48 unit tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [ ] CI passes

closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)