### PR TITLE
fix(compat): fix 5 breaking type/query mismatches (closes #38, #39, #58, #59, #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.6.11] — 2026-04-13
+
+### Fixed
+- **BREAKING** `Order` and `Position` monetary fields (`size`, `price`, `fill_size`, `fill_price`, `pnl`, `avg_price`, `current_price`): changed from `Option<f64>` to `Option<String>` — platform returns decimal strings (`"0.65"`), not JSON numbers, causing serde deserialization failures (closes #38)
+- **BREAKING** `get_whale_feed()`: send `?minSize=X` instead of `?min_size=X`; `get_news_signals()`: send `?minConfidence=X` instead of `?min_confidence=X` — platform expects camelCase query parameters (closes #39)
+- **BREAKING** `Market` struct: rename `title` to `name`, replace `tokens: Vec<Token>` with `base_token`/`quote_token` fields, rename `volume` to `volume_24h` (serde `"volume24h"`), add `price`, `change_24h`, `liquidity`, `created_at` — aligns with actual platform response shape (closes #58)
+- **BREAKING** `Portfolio` struct: rename `balance` to `available_balance` (serde `"availableBalance"`), replace `total_pnl` with `unrealized_pnl`/`realized_pnl`, change monetary fields to `Option<String>`, add `updated_at` — aligns with actual platform response shape (closes #59)
+- **BREAKING** `TraderScore` struct: rename `score` to `overall`, remove phantom fields (`total_trades`, `win_rate`, `profit_factor`), add `profitability`, `consistency`, `risk_management`, `volume`, `percentile`, `updated_at` — aligns with actual platform response shape (closes #60)
+
 ## [1.6.10] — 2026-04-13
 
 ### Fixed

--- a/src/client.rs
+++ b/src/client.rs
@@ -754,7 +754,7 @@ impl PolyforgeClient {
     /// Get the whale trade feed.
     pub async fn get_whale_feed(&self, min_size: Option<u64>) -> Result<PaginatedResponse<WhaleTrade>> {
         let qs = match min_size {
-            Some(s) => format!("?min_size={}", encode(&s.to_string())),
+            Some(s) => format!("?minSize={}", encode(&s.to_string())),
             None => String::new(),
         };
         self.get(&format!("/api/v1/whales/feed{qs}")).await
@@ -763,7 +763,7 @@ impl PolyforgeClient {
     /// Get AI-powered news signals.
     pub async fn get_news_signals(&self, min_confidence: Option<u32>) -> Result<PaginatedResponse<NewsSignal>> {
         let qs = match min_confidence {
-            Some(c) => format!("?min_confidence={}", encode(&c.to_string())),
+            Some(c) => format!("?minConfidence={}", encode(&c.to_string())),
             None => String::new(),
         };
         self.get(&format!("/api/v1/news/signals{qs}")).await

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,13 +30,23 @@ pub struct PaginatedResponse<T> {
 #[serde(rename_all = "camelCase")]
 pub struct Market {
     pub id: String,
-    pub title: String,
+    pub name: String,
     #[serde(default)]
     pub category: Option<String>,
     #[serde(default)]
-    pub volume: Option<f64>,
+    pub price: Option<String>,
+    #[serde(rename = "volume24h", default)]
+    pub volume_24h: Option<String>,
+    #[serde(rename = "change24h", default)]
+    pub change_24h: Option<String>,
     #[serde(default)]
-    pub tokens: Vec<Token>,
+    pub liquidity: Option<String>,
+    #[serde(rename = "baseToken", default)]
+    pub base_token: Option<serde_json::Value>,
+    #[serde(rename = "quoteToken", default)]
+    pub quote_token: Option<serde_json::Value>,
+    #[serde(rename = "createdAt", default)]
+    pub created_at: Option<String>,
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
@@ -152,14 +162,18 @@ pub struct StrategyTemplate {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Portfolio {
-    #[serde(default)]
-    pub balance: Option<f64>,
+    #[serde(rename = "availableBalance", default)]
+    pub available_balance: Option<String>,
     #[serde(default)]
     pub positions: Vec<Position>,
     #[serde(default)]
-    pub total_value: Option<f64>,
-    #[serde(default)]
-    pub total_pnl: Option<f64>,
+    pub total_value: Option<String>,
+    #[serde(rename = "unrealizedPnl", default)]
+    pub unrealized_pnl: Option<String>,
+    #[serde(rename = "realizedPnl", default)]
+    pub realized_pnl: Option<String>,
+    #[serde(rename = "updatedAt", default)]
+    pub updated_at: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -173,13 +187,13 @@ pub struct Position {
     #[serde(default)]
     pub token_id: Option<String>,
     #[serde(default)]
-    pub size: Option<f64>,
+    pub size: Option<String>,
     #[serde(default)]
-    pub avg_price: Option<f64>,
+    pub avg_price: Option<String>,
     #[serde(default)]
-    pub current_price: Option<f64>,
+    pub current_price: Option<String>,
     #[serde(default)]
-    pub pnl: Option<f64>,
+    pub pnl: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -196,9 +210,13 @@ pub struct Order {
     #[serde(default)]
     pub side: Option<String>,
     #[serde(default)]
-    pub size: Option<f64>,
+    pub size: Option<String>,
     #[serde(default)]
-    pub price: Option<f64>,
+    pub price: Option<String>,
+    #[serde(default)]
+    pub fill_size: Option<String>,
+    #[serde(default)]
+    pub fill_price: Option<String>,
     #[serde(default)]
     pub status: Option<String>,
     #[serde(default)]
@@ -287,15 +305,21 @@ pub struct CancelOrderResponse {
 #[serde(rename_all = "camelCase")]
 pub struct TraderScore {
     #[serde(default)]
-    pub score: Option<f64>,
+    pub overall: Option<f64>,
     #[serde(default)]
     pub rank: Option<u64>,
     #[serde(default)]
-    pub total_trades: Option<u64>,
+    pub profitability: Option<f64>,
     #[serde(default)]
-    pub win_rate: Option<f64>,
+    pub consistency: Option<f64>,
+    #[serde(rename = "riskManagement", default)]
+    pub risk_management: Option<f64>,
     #[serde(default)]
-    pub profit_factor: Option<f64>,
+    pub volume: Option<f64>,
+    #[serde(default)]
+    pub percentile: Option<f64>,
+    #[serde(rename = "updatedAt", default)]
+    pub updated_at: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }


### PR DESCRIPTION
## Summary

- **#38**: `Order` and `Position` monetary fields changed from `Option<f64>` to `Option<String>` — platform returns decimal strings (`"0.65"`), not JSON numbers
- **#39**: `get_whale_feed()` and `get_news_signals()` now send camelCase query params (`minSize`, `minConfidence`) instead of snake_case
- **#58**: `Market` struct aligned with platform — `title`→`name`, removed `tokens` vec, added `baseToken`/`quoteToken`/`volume24h`/`change24h`/`liquidity`/`createdAt`/`price`
- **#59**: `Portfolio` struct aligned — `balance`→`availableBalance`, `total_pnl` split into `unrealizedPnl`/`realizedPnl`, monetary fields now `Option<String>`, added `updatedAt`
- **#60**: `TraderScore` struct aligned — `score`→`overall`, removed phantom fields, added `profitability`/`consistency`/`riskManagement`/`volume`/`percentile`/`updatedAt`

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 73 tests pass
- [x] `cargo clippy -- -D warnings` — clean

Closes #38, closes #39, closes #58, closes #59, closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)