### PR TITLE
fix(compat): fix 7 breaking type/field mismatches with platform API (closes #33, #34, #35, #36, #37, #51, #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.6.13] — 2026-04-13
+
+### Fixed
+- **BREAKING** `ClosePositionParams.size`: changed from `Option<f64>` to `Option<String>` — platform's `ClosePositionDto.size` uses `@IsNumberString()` which requires a string value, causing 400 Bad Request on every `close_position()` call with a size (closes #33)
+- **BREAKING** `Order.status`: changed from `Option<String>` to `Option<OrderStatus>` — added typed `OrderStatus` enum with all 12 platform variants (PENDING, SUBMITTED, LIVE, MATCHED, DELAYED, MINED, CONFIRMED, PARTIAL, CANCELLED, UNMATCHED, FAILED, ERROR); `ListOrdersParams.status` also changed to `Option<OrderStatus>` for compile-time safety (closes #34)
+- **BREAKING** `StrategyStatus`: added missing `Error` and `Archived` variants — deserialization failed when platform returned `"ERROR"` or `"ARCHIVED"` status, breaking `list_strategies()` and `get_strategy()` (closes #35)
+- **BREAKING** `Strategy` struct: added typed `triggers`, `conditions`, `actions`, `safety` (`Vec<Block>`), `logic_blocks`, `calc_blocks`, `visibility` (`Visibility` enum), `exec_mode` (`ExecMode` enum), `tick_ms`, `tags`, `version`, `fork_count`, `like_count` fields — strategy blocks were only accessible through the untyped `extra` catch-all (closes #36)
+- **BREAKING** `create_strategy()`: changed signature from `(name, description, market_id)` to `(&CreateStrategyParams)` — new `CreateStrategyParams` struct includes all 15 platform DTO fields (blocks, visibility, execMode, tickMs, tags, variables, canvas) so strategies can actually be created with block configuration (closes #37)
+- **BREAKING** `CopyConfig` struct: renamed `source_trader` to `target_wallet` (serde `"targetWallet"`), renamed `max_size` to `max_exposure` (serde `"maxExposure"`, type changed to `Option<String>`), added `mode` (`CopyMode` enum: PERCENTAGE/FIXED/MIRROR), `size_value`, `max_daily_loss`, `price_offset` fields — all fields were either wrong-named or missing, causing silent data loss on deserialization (closes #51)
+- Added `run_backtest()` method with `RunBacktestParams` struct matching platform's `CreateBacktestDto` (strategyId, dateRangeStart, dateRangeEnd, quickMode, strategyBlocks, marketBindings) — does NOT include `initialBalance` which the platform silently discards (closes #68)
+
+### Added
+- `OrderStatus` enum — 12-variant typed enum for order lifecycle status
+- `Visibility` enum — PRIVATE, PUBLIC, UNLISTED
+- `ExecMode` enum — TICK, EVENT, HYBRID
+- `CopyMode` enum — PERCENTAGE, FIXED, MIRROR
+- `Block`, `LogicBlock`, `CalcBlock` structs — typed strategy block representations
+- `CreateStrategyParams` struct — full strategy creation with all platform DTO fields
+- `RunBacktestParams` struct — backtest parameters matching platform contract
+- `Backtest` struct — backtest result type
+- 15 new unit tests covering all 7 fixes
+
 ## [1.6.12] — 2026-04-13
 
 ### Security

--- a/src/client.rs
+++ b/src/client.rs
@@ -471,20 +471,15 @@ impl PolyforgeClient {
             .await
     }
 
-    /// Create a new strategy with a name and optional description.
+    /// Create a new strategy with full block configuration.
+    ///
+    /// Use [`CreateStrategyParams`] to specify blocks, visibility, execution mode,
+    /// tags, and other strategy properties.
     pub async fn create_strategy(
         &self,
-        name: &str,
-        description: Option<&str>,
-        market_id: Option<&str>,
+        params: &CreateStrategyParams,
     ) -> Result<Strategy> {
-        let mut body = json!({ "name": name });
-        if let Some(desc) = description {
-            body["description"] = json!(desc);
-        }
-        if let Some(mid) = market_id {
-            body["marketId"] = json!(mid);
-        }
+        let body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
         self.post("/api/v1/strategies", &body).await
     }
 
@@ -598,6 +593,20 @@ impl PolyforgeClient {
     }
 
     // -----------------------------------------------------------------------
+    // Backtesting
+    // -----------------------------------------------------------------------
+
+    /// Run a backtest with the given parameters.
+    ///
+    /// The platform does **not** accept an `initialBalance` field.
+    /// Use [`RunBacktestParams`] to specify strategy ID, date range, quick mode,
+    /// strategy blocks, and market bindings.
+    pub async fn run_backtest(&self, params: &RunBacktestParams) -> Result<Backtest> {
+        let body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
+        self.post("/api/v1/backtests", &body).await
+    }
+
+    // -----------------------------------------------------------------------
     // Portfolio & Orders
     // -----------------------------------------------------------------------
 
@@ -613,7 +622,8 @@ impl PolyforgeClient {
             qp.push(("limit", l.to_string()));
         }
         if let Some(ref s) = params.status {
-            qp.push(("status", s.clone()));
+            let val = serde_json::to_value(s).unwrap_or_default();
+            qp.push(("status", val.as_str().unwrap_or_default().to_string()));
         }
         if let Some(ref s) = params.strategy_id {
             qp.push(("strategyId", s.clone()));
@@ -1864,5 +1874,224 @@ mod tests {
         let json = r#"[{"id":"s1"},{"id":"s2"}]"#;
         let result = serde_json::from_str::<PaginatedResponse<Strategy>>(json);
         assert!(result.is_err(), "bare array must not deserialize as PaginatedResponse");
+    }
+
+    // -----------------------------------------------------------------------
+    // Breaking compat fixes (#33, #34, #35, #36, #37, #51, #68)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_close_position_size_serializes_as_string() {
+        // #33: size must be a JSON string, not a number
+        let params = ClosePositionParams {
+            token_id: "tok-123".into(),
+            size: Some("100".into()),
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["size"], serde_json::Value::String("100".to_string()));
+    }
+
+    #[test]
+    fn test_close_position_size_omitted_when_none() {
+        // #33: size should not appear in JSON when None
+        let params = ClosePositionParams {
+            token_id: "tok-123".into(),
+            size: None,
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert!(json.get("size").is_none());
+    }
+
+    #[test]
+    fn test_order_status_enum_deserializes_all_variants() {
+        // #34: All 12 OrderStatus variants must deserialize
+        let variants = [
+            "PENDING", "SUBMITTED", "LIVE", "MATCHED", "DELAYED", "MINED",
+            "CONFIRMED", "PARTIAL", "CANCELLED", "UNMATCHED", "FAILED", "ERROR",
+        ];
+        for v in &variants {
+            let json = format!("\"{}\"", v);
+            let status: OrderStatus = serde_json::from_str(&json).unwrap();
+            let serialized = serde_json::to_value(&status).unwrap();
+            assert_eq!(serialized, serde_json::Value::String(v.to_string()));
+        }
+    }
+
+    #[test]
+    fn test_order_status_used_in_order_struct() {
+        // #34: Order.status should be typed OrderStatus, not String
+        let json = r#"{"id":"o1","status":"CONFIRMED"}"#;
+        let order: Order = serde_json::from_str(json).unwrap();
+        assert_eq!(order.status, Some(OrderStatus::Confirmed));
+    }
+
+    #[test]
+    fn test_strategy_status_error_and_archived() {
+        // #35: ERROR and ARCHIVED must deserialize
+        let json = r#""ERROR""#;
+        let status: StrategyStatus = serde_json::from_str(json).unwrap();
+        assert_eq!(status, StrategyStatus::Error);
+
+        let json = r#""ARCHIVED""#;
+        let status: StrategyStatus = serde_json::from_str(json).unwrap();
+        assert_eq!(status, StrategyStatus::Archived);
+    }
+
+    #[test]
+    fn test_strategy_has_block_arrays() {
+        // #36: Strategy must have triggers, conditions, actions, safety arrays
+        let json = r#"{
+            "id": "s1",
+            "triggers": [{"type":"price_cross","enabled":true}],
+            "conditions": [],
+            "actions": [{"type":"place_order"}],
+            "safety": [{"type":"stop_loss"}],
+            "visibility": "PUBLIC",
+            "execMode": "TICK",
+            "tickMs": 5000,
+            "tags": ["crypto","automated"],
+            "forkCount": 12,
+            "likeCount": 42,
+            "version": 3
+        }"#;
+        let strategy: Strategy = serde_json::from_str(json).unwrap();
+        assert_eq!(strategy.triggers.len(), 1);
+        assert_eq!(strategy.actions.len(), 1);
+        assert_eq!(strategy.safety.len(), 1);
+        assert_eq!(strategy.visibility, Some(Visibility::Public));
+        assert_eq!(strategy.exec_mode, Some(ExecMode::Tick));
+        assert_eq!(strategy.tick_ms, Some(5000));
+        assert_eq!(strategy.tags, vec!["crypto", "automated"]);
+        assert_eq!(strategy.fork_count, Some(12));
+        assert_eq!(strategy.like_count, Some(42));
+        assert_eq!(strategy.version, Some(3));
+    }
+
+    #[test]
+    fn test_create_strategy_params_serializes_all_fields() {
+        // #37: CreateStrategyParams must include blocks, visibility, execMode, tags
+        let params = CreateStrategyParams {
+            name: "My Strategy".into(),
+            description: Some("Test".into()),
+            market_id: Some("m1".into()),
+            visibility: Some(Visibility::Public),
+            exec_mode: Some(ExecMode::Tick),
+            tick_ms: Some(5000),
+            triggers: Some(vec![]),
+            conditions: Some(vec![]),
+            actions: Some(vec![]),
+            safety: Some(vec![]),
+            logic_blocks: None,
+            calc_blocks: None,
+            tags: Some(vec!["test".into()]),
+            variables: None,
+            canvas: None,
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["name"], "My Strategy");
+        assert_eq!(json["visibility"], "PUBLIC");
+        assert_eq!(json["execMode"], "TICK");
+        assert_eq!(json["tickMs"], 5000);
+        assert!(json["triggers"].is_array());
+        assert!(json["tags"].is_array());
+        // logicBlocks and calcBlocks omitted when None
+        assert!(json.get("logicBlocks").is_none());
+    }
+
+    #[test]
+    fn test_copy_config_deserializes_platform_fields() {
+        // #51: CopyConfig must use targetWallet, mode, maxExposure etc.
+        let json = r#"{
+            "id": "cc1",
+            "targetWallet": "0xabc123",
+            "mode": "PERCENTAGE",
+            "sizeValue": "50",
+            "maxExposure": "1000",
+            "maxDailyLoss": "100",
+            "priceOffset": "0.01",
+            "enabled": true
+        }"#;
+        let config: CopyConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.target_wallet, Some("0xabc123".to_string()));
+        assert_eq!(config.mode, Some(CopyMode::Percentage));
+        assert_eq!(config.size_value, Some("50".to_string()));
+        assert_eq!(config.max_exposure, Some("1000".to_string()));
+        assert_eq!(config.max_daily_loss, Some("100".to_string()));
+        assert_eq!(config.price_offset, Some("0.01".to_string()));
+        assert_eq!(config.enabled, Some(true));
+    }
+
+    #[test]
+    fn test_copy_config_no_source_trader_field() {
+        // #51: Verify that the old source_trader field name does NOT work
+        let json = r#"{"id":"cc1","sourceTrader":"0xabc"}"#;
+        let config: CopyConfig = serde_json::from_str(json).unwrap();
+        // sourceTrader goes into extra, not target_wallet
+        assert_eq!(config.target_wallet, None);
+    }
+
+    #[test]
+    fn test_run_backtest_params_no_initial_balance() {
+        // #68: RunBacktestParams must NOT have initialBalance
+        let params = RunBacktestParams {
+            strategy_id: Some("s1".into()),
+            date_range_start: Some("2025-01-01".into()),
+            date_range_end: Some("2025-12-31".into()),
+            quick_mode: Some(true),
+            strategy_blocks: None,
+            market_bindings: None,
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert!(json.get("initialBalance").is_none());
+        assert_eq!(json["strategyId"], "s1");
+        assert_eq!(json["dateRangeStart"], "2025-01-01");
+        assert_eq!(json["dateRangeEnd"], "2025-12-31");
+        assert_eq!(json["quickMode"], true);
+    }
+
+    #[test]
+    fn test_run_backtest_params_with_market_bindings() {
+        // #68: market_bindings should serialize correctly
+        let mut bindings = std::collections::HashMap::new();
+        bindings.insert("block-1".to_string(), "market-abc".to_string());
+        let params = RunBacktestParams {
+            strategy_id: None,
+            date_range_start: None,
+            date_range_end: None,
+            quick_mode: None,
+            strategy_blocks: None,
+            market_bindings: Some(bindings),
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["marketBindings"]["block-1"], "market-abc");
+    }
+
+    #[test]
+    fn test_order_status_serializes_for_query_params() {
+        // #34: OrderStatus should serialize to correct string for query params
+        let status = OrderStatus::Live;
+        let val = serde_json::to_value(&status).unwrap();
+        assert_eq!(val.as_str().unwrap(), "LIVE");
+    }
+
+    #[test]
+    fn test_visibility_enum_serializes() {
+        assert_eq!(serde_json::to_value(Visibility::Private).unwrap(), "PRIVATE");
+        assert_eq!(serde_json::to_value(Visibility::Public).unwrap(), "PUBLIC");
+        assert_eq!(serde_json::to_value(Visibility::Unlisted).unwrap(), "UNLISTED");
+    }
+
+    #[test]
+    fn test_exec_mode_enum_serializes() {
+        assert_eq!(serde_json::to_value(ExecMode::Tick).unwrap(), "TICK");
+        assert_eq!(serde_json::to_value(ExecMode::Event).unwrap(), "EVENT");
+        assert_eq!(serde_json::to_value(ExecMode::Hybrid).unwrap(), "HYBRID");
+    }
+
+    #[test]
+    fn test_copy_mode_enum_serializes() {
+        assert_eq!(serde_json::to_value(CopyMode::Percentage).unwrap(), "PERCENTAGE");
+        assert_eq!(serde_json::to_value(CopyMode::Fixed).unwrap(), "FIXED");
+        assert_eq!(serde_json::to_value(CopyMode::Mirror).unwrap(), "MIRROR");
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,7 +90,73 @@ pub enum StrategyStatus {
     Idle,
     Running,
     Paused,
+    Error,
     Paper,
+    Archived,
+}
+
+/// Strategy visibility.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Visibility {
+    Private,
+    Public,
+    Unlisted,
+}
+
+/// Strategy execution mode.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ExecMode {
+    Tick,
+    Event,
+    Hybrid,
+}
+
+/// A strategy block (trigger, condition, action, or safety).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Block {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(rename = "type", default)]
+    pub block_type: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub config: Option<serde_json::Value>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// A logic block used in strategy flow control.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogicBlock {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(rename = "type", default)]
+    pub block_type: Option<String>,
+    #[serde(default)]
+    pub config: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// A calculation block used in strategy computations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalcBlock {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(rename = "type", default)]
+    pub block_type: Option<String>,
+    #[serde(default)]
+    pub config: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
 }
 
 /// Trading mode used when starting a strategy.
@@ -115,6 +181,32 @@ pub struct Strategy {
     pub status: Option<StrategyStatus>,
     #[serde(default)]
     pub mode: Option<TradingMode>,
+    #[serde(default)]
+    pub visibility: Option<Visibility>,
+    #[serde(default)]
+    pub exec_mode: Option<ExecMode>,
+    #[serde(default)]
+    pub tick_ms: Option<u64>,
+    #[serde(default)]
+    pub triggers: Vec<Block>,
+    #[serde(default)]
+    pub conditions: Vec<Block>,
+    #[serde(default)]
+    pub actions: Vec<Block>,
+    #[serde(default)]
+    pub safety: Vec<Block>,
+    #[serde(default)]
+    pub logic_blocks: Option<Vec<LogicBlock>>,
+    #[serde(default)]
+    pub calc_blocks: Option<Vec<CalcBlock>>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub version: Option<u32>,
+    #[serde(default)]
+    pub fork_count: Option<u64>,
+    #[serde(default)]
+    pub like_count: Option<u64>,
     #[serde(default)]
     pub pnl: Option<f64>,
     #[serde(default)]
@@ -150,6 +242,74 @@ pub struct StrategyTemplate {
     pub description: Option<String>,
     #[serde(default)]
     pub category: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Parameters for creating a strategy with full block configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateStrategyParams {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub market_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<Visibility>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exec_mode: Option<ExecMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tick_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub triggers: Option<Vec<Block>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conditions: Option<Vec<Block>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions: Option<Vec<Block>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub safety: Option<Vec<Block>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logic_blocks: Option<Vec<LogicBlock>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calc_blocks: Option<Vec<CalcBlock>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variables: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canvas: Option<serde_json::Value>,
+}
+
+/// Parameters for running a backtest.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RunBacktestParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_range_start: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_range_end: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quick_mode: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy_blocks: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub market_bindings: Option<std::collections::HashMap<String, String>>,
+}
+
+/// A backtest result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Backtest {
+    pub id: String,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub strategy_id: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -198,6 +358,24 @@ pub struct Position {
     pub extra: serde_json::Value,
 }
 
+/// Order lifecycle status.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrderStatus {
+    Pending,
+    Submitted,
+    Live,
+    Matched,
+    Delayed,
+    Mined,
+    Confirmed,
+    Partial,
+    Cancelled,
+    Unmatched,
+    Failed,
+    Error,
+}
+
 /// An order.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -218,7 +396,7 @@ pub struct Order {
     #[serde(default)]
     pub fill_price: Option<String>,
     #[serde(default)]
-    pub status: Option<String>,
+    pub status: Option<OrderStatus>,
     #[serde(default)]
     pub created_at: Option<String>,
     #[serde(flatten)]
@@ -229,7 +407,7 @@ pub struct Order {
 #[derive(Debug, Default)]
 pub struct ListOrdersParams {
     pub limit: Option<u32>,
-    pub status: Option<String>,
+    pub status: Option<OrderStatus>,
     pub strategy_id: Option<String>,
     pub from: Option<String>,
     pub to: Option<String>,
@@ -240,8 +418,9 @@ pub struct ListOrdersParams {
 pub struct ClosePositionParams {
     #[serde(rename = "tokenId")]
     pub token_id: String,
+    /// Size as a number string (e.g. `"100"`). Platform validates with `@IsNumberString()`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub size: Option<f64>,
+    pub size: Option<String>,
 }
 
 /// Parameters for redeeming a resolved position.
@@ -393,15 +572,38 @@ pub struct Alert {
     pub extra: serde_json::Value,
 }
 
+/// Copy trading mode.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CopyMode {
+    Percentage,
+    Fixed,
+    Mirror,
+}
+
 /// A copy-trading configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CopyConfig {
     pub id: String,
+    /// The Ethereum wallet address to copy trades to.
     #[serde(default)]
-    pub source_trader: Option<String>,
+    pub target_wallet: Option<String>,
+    /// Copy mode: PERCENTAGE, FIXED, or MIRROR.
     #[serde(default)]
-    pub max_size: Option<f64>,
+    pub mode: Option<CopyMode>,
+    /// Size value used with the selected mode.
+    #[serde(default)]
+    pub size_value: Option<String>,
+    /// Maximum exposure as a number string.
+    #[serde(default)]
+    pub max_exposure: Option<String>,
+    /// Maximum daily loss as a number string.
+    #[serde(default)]
+    pub max_daily_loss: Option<String>,
+    /// Price offset as a number string.
+    #[serde(default)]
+    pub price_offset: Option<String>,
     #[serde(default)]
     pub enabled: Option<bool>,
     #[serde(flatten)]


### PR DESCRIPTION
## Summary

Fixes 7 breaking compatibility issues where the Rust SDK types and methods did not match the PolyForge platform API contract:

- **#33** `ClosePositionParams.size` sent as JSON number but platform expects NumberString — changed to `Option<String>`
- **#34** `Order.status` was untyped `String` — added 12-variant `OrderStatus` enum (PENDING through ERROR), used in both `Order` and `ListOrdersParams`
- **#35** `StrategyStatus` missing `ERROR` and `ARCHIVED` — deserialization crashed for strategies in those states
- **#36** `Strategy` struct missing block categories — added typed `Block`, `LogicBlock`, `CalcBlock` structs plus `triggers`, `conditions`, `actions`, `safety` arrays, `visibility`, `execMode`, `tickMs`, `tags`, `version`, `forkCount`, `likeCount`
- **#37** `create_strategy()` only sent name/description/marketId — replaced with `CreateStrategyParams` struct covering all 15 platform DTO fields (blocks, visibility, execMode, tags, variables, canvas)
- **#51** `CopyConfig` fields didn't match platform — renamed `source_trader`→`target_wallet`, `max_size`→`max_exposure`(String), added `mode` (CopyMode enum), `sizeValue`, `maxDailyLoss`, `priceOffset`
- **#68** Added `run_backtest()` with `RunBacktestParams` matching the actual platform DTO (no `initialBalance` which doesn't exist in the platform)

## New Types Added

- `OrderStatus` — 12-variant enum
- `Visibility` — PRIVATE/PUBLIC/UNLISTED
- `ExecMode` — TICK/EVENT/HYBRID
- `CopyMode` — PERCENTAGE/FIXED/MIRROR
- `Block`, `LogicBlock`, `CalcBlock` — strategy block structs
- `CreateStrategyParams` — full strategy creation params
- `RunBacktestParams` — backtest params matching platform
- `Backtest` — backtest result type

## Test plan

- [x] 15 new unit tests covering all 7 fixes
- [x] All 104 tests pass (`cargo test`)
- [x] Zero clippy warnings (`cargo clippy -- -D warnings`)
- [x] Clean build (`cargo build`)
- [x] Serde round-trip verified for all new enums and structs

closes #33, closes #34, closes #35, closes #36, closes #37, closes #51, closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)