### PR TITLE
fix(compat): fix 4 model/endpoint mismatches (closes #61, #62, #75, #77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.6.15] — 2026-04-13
+
+### Fixed
+- `ListMarketsParams`: added `sort` and `closed` fields — users can now sort markets by volume/endDate/newest/etc. and filter by resolution status (closes #75)
+- **BREAKING** `list_strategies()`: changed signature from `(Option<StrategyStatus>)` to `(&ListStrategiesParams)` — new `ListStrategiesParams` struct adds `sort`, `page`, and `limit` alongside the existing `status` filter, enabling full pagination and sorting (closes #77)
+
+### Added
+- `ListStrategiesParams` struct — typed query parameters for `list_strategies()`
+
 ## [1.6.14] — 2026-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ async fn main() -> polyforge::Result<()> {
 
 | Method | Description |
 |--------|-------------|
-| `list_markets(params)` | List markets with search, category, pagination |
+| `list_markets(params)` | List markets with search, category, sort, closed filter, pagination |
 | `get_market(id)` | Get a single market by ID |
 
 ### Strategies
 
 | Method | Description |
 |--------|-------------|
-| `list_strategies(status)` | List strategies, optionally filtered by status |
+| `list_strategies(params)` | List strategies with optional status filter, sorting, and pagination |
 | `get_strategy(id)` | Get a strategy by ID |
 | `create_strategy(name, description)` | Create a new strategy |
 | `create_strategy_from_description(desc, market_id)` | AI-powered strategy creation |

--- a/src/client.rs
+++ b/src/client.rs
@@ -430,6 +430,12 @@ impl PolyforgeClient {
         if let Some(p) = params.page {
             qp.push(("page", p.to_string()));
         }
+        if let Some(ref s) = params.sort {
+            qp.push(("sort", s.clone()));
+        }
+        if let Some(c) = params.closed {
+            qp.push(("closed", c.to_string()));
+        }
 
         let qs = if qp.is_empty() {
             String::new()
@@ -453,14 +459,33 @@ impl PolyforgeClient {
     // Strategies
     // -----------------------------------------------------------------------
 
-    /// List strategies, optionally filtered by status.
-    pub async fn list_strategies(&self, status: Option<StrategyStatus>) -> Result<PaginatedResponse<Strategy>> {
-        let qs = match status {
-            Some(s) => {
-                let val = serde_json::to_value(&s).unwrap_or_default();
-                format!("?status={}", encode(val.as_str().unwrap_or_default()))
+    /// List strategies with optional filtering, sorting, and pagination.
+    pub async fn list_strategies(&self, params: &ListStrategiesParams) -> Result<PaginatedResponse<Strategy>> {
+        let mut qp: Vec<(&str, String)> = Vec::new();
+        if let Some(ref s) = params.status {
+            let val = serde_json::to_value(s).unwrap_or_default();
+            if let Some(v) = val.as_str() {
+                qp.push(("status", v.to_string()));
             }
-            None => String::new(),
+        }
+        if let Some(ref s) = params.sort {
+            qp.push(("sort", s.clone()));
+        }
+        if let Some(p) = params.page {
+            qp.push(("page", p.to_string()));
+        }
+        if let Some(l) = params.limit {
+            qp.push(("limit", l.to_string()));
+        }
+
+        let qs = if qp.is_empty() {
+            String::new()
+        } else {
+            let pairs: Vec<String> = qp
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, encode(v)))
+                .collect();
+            format!("?{}", pairs.join("&"))
         };
         self.get(&format!("/api/v1/strategies{qs}")).await
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -77,6 +77,10 @@ pub struct ListMarketsParams {
     pub category: Option<String>,
     pub limit: Option<u32>,
     pub page: Option<u32>,
+    /// Sort order: `"volume"`, `"endDate"`, `"firstSeenAt"`, `"newest"`, `"closing_soon"`, `"liquidity"`.
+    pub sort: Option<String>,
+    /// Whether to include closed/resolved markets.
+    pub closed: Option<bool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -93,6 +97,19 @@ pub enum StrategyStatus {
     Error,
     Paper,
     Archived,
+}
+
+/// Parameters for listing strategies.
+#[derive(Debug, Default)]
+pub struct ListStrategiesParams {
+    /// Filter by status: `IDLE`, `RUNNING`, `PAUSED`, `PAPER`, etc.
+    pub status: Option<StrategyStatus>,
+    /// Sort order: `"createdAt"`, `"updatedAt"`, `"name"`, `"status"`, `"likeCount"`.
+    pub sort: Option<String>,
+    /// Page number (1-based, default 1).
+    pub page: Option<u32>,
+    /// Items per page (default 20, max 100).
+    pub limit: Option<u32>,
 }
 
 /// Strategy visibility.


### PR DESCRIPTION
## Summary
- **#61**: NewsSignal direction->sentiment, WhaleTrade trader->wallet — already fixed in v1.6.14, closing
- **#62**: AiQueryResponse suggestedActions + sources type — already fixed in v1.6.14, closing
- **#75**: Added `sort` and `closed` query parameters to `ListMarketsParams` and `list_markets()` query string builder
- **#77**: Replaced `list_strategies(Option<StrategyStatus>)` with `list_strategies(&ListStrategiesParams)` supporting `status`, `sort`, `page`, and `limit`

## Test plan
- [x] `cargo test` — 116 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build` — succeeds

closes #61, closes #62, closes #75, closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)