### PR TITLE
fix(types): align Alert, Position, StrategyTemplate with platform schema (closes #107, closes #108, closes #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.6.19] — 2026-04-14
+
+### Fixed
+- **BREAKING:** `Alert` struct: replaced phantom fields (`name`, `market_id`, `condition`, `enabled`) with correct platform fields (`token_id`, `direction`, `price`, `persistent`, `triggered`, `triggered_at`, `created_at`) matching `PriceAlert` Prisma model (closes #107)
+- **BREAKING:** `Position` struct: added missing fields (`id`, `side`, `unrealized_pnl`, `realized_pnl`, `opened_at`) and removed incorrect `pnl` field — platform returns separate unrealized/realized PnL (closes #108)
+- `StrategyTemplate` struct: added `blocks: Vec<Block>` and `popularity: u32` fields for template block configuration and usage score (closes #109)
+- Added `#[serde(rename_all = "camelCase")]` to `StrategyTemplate` for consistent field deserialization
+
 ## [1.6.18] — 2026-04-13
 
 ### Added

--- a/src/client.rs
+++ b/src/client.rs
@@ -2404,19 +2404,26 @@ mod tests {
     }
 
     #[test]
-    fn test_alert_has_name_and_last_triggered_at() {
-        // #23: Alert must have name and lastTriggeredAt, no threshold
+    fn test_alert_has_platform_fields() {
+        // #107: Alert must match platform PriceAlert Prisma model fields
         let json = r#"{
             "id": "a1",
-            "name": "BTC price alert",
-            "marketId": "m1",
-            "condition": "price_above",
-            "enabled": true,
-            "lastTriggeredAt": "2026-04-13T09:00:00Z"
+            "tokenId": "0xtoken123",
+            "direction": "above",
+            "price": "0.65",
+            "persistent": false,
+            "triggered": false,
+            "triggeredAt": null,
+            "createdAt": "2026-04-01T00:00:00Z"
         }"#;
         let alert: Alert = serde_json::from_str(json).unwrap();
-        assert_eq!(alert.name, Some("BTC price alert".to_string()));
-        assert_eq!(alert.last_triggered_at, Some("2026-04-13T09:00:00Z".to_string()));
+        assert_eq!(alert.token_id, Some("0xtoken123".to_string()));
+        assert_eq!(alert.direction, Some("above".to_string()));
+        assert_eq!(alert.price, Some("0.65".to_string()));
+        assert_eq!(alert.persistent, Some(false));
+        assert_eq!(alert.triggered, Some(false));
+        assert_eq!(alert.triggered_at, None);
+        assert_eq!(alert.created_at, Some("2026-04-01T00:00:00Z".to_string()));
     }
 
     #[test]
@@ -2949,5 +2956,47 @@ mod tests {
         assert_eq!(resp.data.len(), 2);
         assert_eq!(resp.data[0].id, "co-1");
         assert_eq!(resp.total, 2);
+    }
+
+    #[test]
+    fn test_position_has_platform_fields() {
+        // #108: Position must match platform response fields
+        let json = r#"{
+            "id": "pos-1",
+            "marketId": "m1",
+            "tokenId": "t1",
+            "side": "BUY",
+            "size": "100.5",
+            "avgPrice": "0.65",
+            "currentPrice": "0.72",
+            "unrealizedPnl": "7.035",
+            "realizedPnl": "12.50",
+            "openedAt": "2026-03-15T10:00:00Z"
+        }"#;
+        let pos: Position = serde_json::from_str(json).unwrap();
+        assert_eq!(pos.id, Some("pos-1".to_string()));
+        assert_eq!(pos.side, Some("BUY".to_string()));
+        assert_eq!(pos.unrealized_pnl, Some("7.035".to_string()));
+        assert_eq!(pos.realized_pnl, Some("12.50".to_string()));
+        assert_eq!(pos.opened_at, Some("2026-03-15T10:00:00Z".to_string()));
+    }
+
+    #[test]
+    fn test_strategy_template_has_blocks_and_popularity() {
+        // #109: StrategyTemplate must include blocks and popularity
+        let json = r#"{
+            "id": "tmpl-1",
+            "name": "Mean Reversion",
+            "description": "Buy low sell high",
+            "category": "Technical",
+            "blocks": [
+                {"id": "b1", "type": "PRICE_TRIGGER", "label": "MA Cross"}
+            ],
+            "popularity": 342
+        }"#;
+        let tmpl: StrategyTemplate = serde_json::from_str(json).unwrap();
+        assert_eq!(tmpl.name, Some("Mean Reversion".to_string()));
+        assert_eq!(tmpl.blocks.len(), 1);
+        assert_eq!(tmpl.popularity, 342);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -249,8 +249,9 @@ pub struct StrategyStatusResponse {
     pub extra: serde_json::Value,
 }
 
-/// A strategy template.
+/// A strategy template with block configuration and popularity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StrategyTemplate {
     pub id: String,
     #[serde(default)]
@@ -259,6 +260,12 @@ pub struct StrategyTemplate {
     pub description: Option<String>,
     #[serde(default)]
     pub category: Option<String>,
+    /// The template's block configuration.
+    #[serde(default)]
+    pub blocks: Vec<Block>,
+    /// Usage/popularity score.
+    #[serde(default)]
+    pub popularity: u32,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -356,13 +363,22 @@ pub struct Portfolio {
 }
 
 /// A portfolio position.
+///
+/// Field names match the platform position response: `id`, `marketId`,
+/// `tokenId`, `side`, `size`, `avgPrice`, `currentPrice`,
+/// `unrealizedPnl`, `realizedPnl`, `openedAt`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Position {
     #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
     pub market_id: Option<String>,
     #[serde(default)]
     pub token_id: Option<String>,
+    /// Position direction: "BUY" or "SELL".
+    #[serde(default)]
+    pub side: Option<String>,
     #[serde(default)]
     pub size: Option<String>,
     #[serde(default)]
@@ -370,7 +386,11 @@ pub struct Position {
     #[serde(default)]
     pub current_price: Option<String>,
     #[serde(default)]
-    pub pnl: Option<String>,
+    pub unrealized_pnl: Option<String>,
+    #[serde(default)]
+    pub realized_pnl: Option<String>,
+    #[serde(default)]
+    pub opened_at: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -576,21 +596,30 @@ pub struct NewsSignal {
 // Configuration: Alerts, Copy Trading, Webhooks
 // ---------------------------------------------------------------------------
 
-/// A price or event alert.
+/// A price alert on a specific token.
+///
+/// Field names match the platform `PriceAlert` Prisma model:
+/// `tokenId`, `direction`, `price`, `persistent`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Alert {
     pub id: String,
     #[serde(default)]
-    pub name: Option<String>,
+    pub token_id: Option<String>,
+    /// Alert direction: "above" or "below".
     #[serde(default)]
-    pub market_id: Option<String>,
+    pub direction: Option<String>,
+    /// Price threshold as a decimal string.
     #[serde(default)]
-    pub condition: Option<String>,
+    pub price: Option<String>,
     #[serde(default)]
-    pub enabled: Option<bool>,
+    pub persistent: Option<bool>,
     #[serde(default)]
-    pub last_triggered_at: Option<String>,
+    pub triggered: Option<bool>,
+    #[serde(default)]
+    pub triggered_at: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }


### PR DESCRIPTION
## Summary

- **Alert struct**: Replaced phantom fields (`name`, `market_id`, `condition`, `enabled`) with correct platform fields (`token_id`, `direction`, `price`, `persistent`, `triggered`, `triggered_at`, `created_at`) — verified against `PriceAlert` Prisma model
- **Position struct**: Added missing fields (`id`, `side`, `unrealized_pnl`, `realized_pnl`, `opened_at`) and removed incorrect `pnl` field — platform returns separate unrealized/realized PnL
- **StrategyTemplate struct**: Added `blocks: Vec<Block>` and `popularity: u32` fields; added `#[serde(rename_all = "camelCase")]` for consistent deserialization

## Verification

All field names verified against PolyForge platform source:
- `prisma/schema.prisma` → `PriceAlert` model (line 758)
- Platform portfolio response → separate `unrealizedPnl`/`realizedPnl` fields
- Strategy templates endpoint → includes `blocks` array and `popularity` integer

## Test plan

- [x] 152 unit tests + 2 doc-tests pass (0 failures)
- [x] Updated test: `test_alert_has_platform_fields` — validates new Alert field deserialization
- [x] New test: `test_position_has_platform_fields` — validates all Position fields
- [x] New test: `test_strategy_template_has_blocks_and_popularity` — validates blocks/popularity

BREAKING CHANGE: `Alert` and `Position` field names have changed.

closes #107, closes #108, closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)