### PR TITLE
fix(client): serialize offset query param in browse_marketplace (closes #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.20] — 2026-04-14
+
+### Fixed
+- `browse_marketplace()`: `offset` query parameter was defined in `BrowseMarketplaceParams` but never serialized into the URL — users could not paginate past the first page of marketplace results (closes #28)
+
 ## [1.6.19] — 2026-04-14
 
 ### Fixed

--- a/src/client.rs
+++ b/src/client.rs
@@ -861,6 +861,9 @@ impl PolyforgeClient {
         if let Some(limit) = params.limit {
             qp.push(format!("limit={limit}"));
         }
+        if let Some(offset) = params.offset {
+            qp.push(format!("offset={offset}"));
+        }
         let qs = if qp.is_empty() {
             String::new()
         } else {
@@ -2998,5 +3001,24 @@ mod tests {
         assert_eq!(tmpl.name, Some("Mean Reversion".to_string()));
         assert_eq!(tmpl.blocks.len(), 1);
         assert_eq!(tmpl.popularity, 342);
+    }
+
+    #[test]
+    fn test_browse_marketplace_params_has_offset() {
+        // Verify BrowseMarketplaceParams has offset field and it's usable
+        let params = BrowseMarketplaceParams {
+            sort: Some("newest".to_string()),
+            tag: Some("crypto".to_string()),
+            limit: Some(20),
+            offset: Some(40),
+        };
+        assert_eq!(params.offset, Some(40));
+        assert_eq!(params.limit, Some(20));
+    }
+
+    #[test]
+    fn test_browse_marketplace_params_offset_default() {
+        let params = BrowseMarketplaceParams::default();
+        assert_eq!(params.offset, None);
     }
 }


### PR DESCRIPTION
## Summary
- `browse_marketplace()` had `offset` in `BrowseMarketplaceParams` but never serialized it into the query string
- Users could not paginate past the first page of marketplace results — `offset: Some(40)` was silently ignored
- Added the missing `if let Some(offset) = params.offset { qp.push(...) }` block
- 154 unit tests + 2 doc tests pass (2 new tests added)

## What changed
- `src/client.rs`: Added offset serialization in `browse_marketplace()` query builder + 2 tests
- `CHANGELOG.md`: Added entry for v1.6.20

## Verification
- Verified against platform: `marketplace.controller.ts` accepts `offset` as `@IsNumberString()` query param
- `marketplace.service.ts` uses `skip: offset` in Prisma query

closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)