### PR TITLE
fix(compat): use correct `period` param for get_price_history (closes #114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.2] — 2026-04-15
+
+### Fixed
+- **Price history params** — `get_price_history()` now sends `period` (with values `"1h"`, `"6h"`, `"24h"`) instead of the incorrect `resolution` parameter. Removed unsupported `from`/`to` params that were silently ignored by the platform. (closes #114)
+
 ## [1.7.1] — 2026-04-14
 
 ### Security

--- a/src/client.rs
+++ b/src/client.rs
@@ -487,8 +487,7 @@ impl PolyforgeClient {
 
     /// Get price history for a market token.
     ///
-    /// Pass `None` for `params` to use server defaults (`resolution = "1h"`,
-    /// `limit = 200`).
+    /// Pass `None` for `params` to use server defaults (`period = "1h"`).
     pub async fn get_price_history(
         &self,
         token_id: &str,
@@ -496,14 +495,8 @@ impl PolyforgeClient {
     ) -> Result<Vec<PriceHistoryEntry>> {
         let mut qp: Vec<(&str, String)> = Vec::new();
         if let Some(ref p) = params {
-            if let Some(ref r) = p.resolution {
-                qp.push(("resolution", r.clone()));
-            }
-            if let Some(ref f) = p.from {
-                qp.push(("from", f.clone()));
-            }
-            if let Some(ref t) = p.to {
-                qp.push(("to", t.clone()));
+            if let Some(ref r) = p.period {
+                qp.push(("period", r.clone()));
             }
             if let Some(l) = p.limit {
                 qp.push(("limit", l.to_string()));
@@ -2819,37 +2812,29 @@ mod tests {
     #[test]
     fn test_price_history_params_default() {
         let params = PriceHistoryParams::default();
-        assert!(params.resolution.is_none());
-        assert!(params.from.is_none());
-        assert!(params.to.is_none());
+        assert!(params.period.is_none());
         assert!(params.limit.is_none());
     }
 
     #[test]
     fn test_price_history_params_serializes() {
         let params = PriceHistoryParams {
-            resolution: Some("1d".into()),
-            from: Some("2026-01-01T00:00:00Z".into()),
-            to: Some("2026-01-31T23:59:59Z".into()),
+            period: Some("6h".into()),
             limit: Some(500),
         };
         let val = serde_json::to_value(&params).unwrap();
-        assert_eq!(val["resolution"], "1d");
-        assert_eq!(val["from"], "2026-01-01T00:00:00Z");
-        assert_eq!(val["to"], "2026-01-31T23:59:59Z");
+        assert_eq!(val["period"], "6h");
         assert_eq!(val["limit"], 500);
     }
 
     #[test]
     fn test_price_history_params_omits_none_fields() {
         let params = PriceHistoryParams {
-            resolution: Some("1h".into()),
+            period: Some("1h".into()),
             ..Default::default()
         };
         let val = serde_json::to_value(&params).unwrap();
-        assert_eq!(val["resolution"], "1h");
-        assert!(val.get("from").is_none());
-        assert!(val.get("to").is_none());
+        assert_eq!(val["period"], "1h");
         assert!(val.get("limit").is_none());
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1082,16 +1082,10 @@ pub struct LpPosition {
 #[derive(Debug, Default, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PriceHistoryParams {
-    /// Candle resolution: `"1m"`, `"1h"`, or `"1d"` (default `"1h"`).
+    /// Candle period: `"1h"`, `"6h"`, or `"24h"` (default `"1h"`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub resolution: Option<String>,
-    /// Start of the time range (ISO 8601).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub from: Option<String>,
-    /// End of the time range (ISO 8601).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub to: Option<String>,
-    /// Maximum number of entries (1–1000, default 200).
+    pub period: Option<String>,
+    /// Maximum number of entries (1–500, default server-side).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
 }


### PR DESCRIPTION
## Summary

- Renamed `resolution` → `period` in `PriceHistoryParams` struct
- Updated doc comments from `"1m"/"1h"/"1d"` to `"1h"/"6h"/"24h"` to match platform's `PriceHistoryQueryDto`
- Removed unsupported `from`/`to` fields (platform silently strips them via whitelist validation pipe)
- Updated all 3 related tests

## Impact

Every `get_price_history()` call using `resolution` was silently falling back to the platform's default period. Users were getting unexpected OHLCV data with no error.

## Test plan

- [x] All 160 unit tests + 2 doc-tests pass
- [x] `cargo build` clean
- [x] Serialization tests updated to verify `period` field name

closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)