### PR TITLE
fix(compat): correct Block, Backtest, CreateConditionalOrderParams structs (closes #115, closes #116, closes #117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.7.3] — 2026-04-15
+
+### Fixed
+- **CreateConditionalOrderParams** — add required `market_id` field, rename `condition_type` to `order_type` (serializes as `type`), add `trailing_pct` field. (closes #115)
+- **Block struct** — replace `enabled: Option<bool>` with `connections: Vec<String>` to match platform's strategy block graph. (closes #116)
+- **Backtest struct** — add 10 missing platform fields: `start_date`, `end_date`, `initial_balance`, `final_balance`, `pnl`, `trade_count`, `win_rate`, `sharpe_ratio`, `max_drawdown`, `completed_at`. (closes #117)
+
 ## [1.7.2] — 2026-04-15
 
 ### Fixed

--- a/src/client.rs
+++ b/src/client.rs
@@ -2955,33 +2955,39 @@ mod tests {
     #[test]
     fn test_create_conditional_order_params_serializes_camelcase() {
         let params = CreateConditionalOrderParams {
+            market_id: "mkt-1".into(),
             token_id: "tok-1".into(),
+            order_type: "STOP_LOSS".into(),
             side: "BUY".into(),
             outcome: "YES".into(),
             size: 50.0,
             trigger_price: 0.65,
             limit_price: Some(0.67),
-            condition_type: Some("STOP_LIMIT".into()),
+            trailing_pct: None,
             expires_at: None,
         };
         let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["marketId"], "mkt-1");
         assert_eq!(json["tokenId"], "tok-1");
+        assert_eq!(json["type"], "STOP_LOSS");
         assert_eq!(json["triggerPrice"], 0.65);
         assert_eq!(json["limitPrice"], 0.67);
-        assert_eq!(json["conditionType"], "STOP_LIMIT");
         assert!(json.get("expiresAt").is_none());
+        assert!(json.get("trailingPct").is_none());
     }
 
     #[test]
     fn test_create_conditional_order_validation_rejects_nan_size() {
         let params = CreateConditionalOrderParams {
+            market_id: "mkt-1".into(),
             token_id: "tok-1".into(),
+            order_type: "STOP_LOSS".into(),
             side: "BUY".into(),
             outcome: "YES".into(),
             size: f64::NAN,
             trigger_price: 0.65,
             limit_price: None,
-            condition_type: None,
+            trailing_pct: None,
             expires_at: None,
         };
         let rt = tokio::runtime::Runtime::new().unwrap();
@@ -2996,13 +3002,15 @@ mod tests {
     #[test]
     fn test_create_conditional_order_validation_rejects_negative_trigger_price() {
         let params = CreateConditionalOrderParams {
+            market_id: "mkt-1".into(),
             token_id: "tok-1".into(),
+            order_type: "STOP_LOSS".into(),
             side: "BUY".into(),
             outcome: "YES".into(),
             size: 10.0,
             trigger_price: -0.5,
             limit_price: None,
-            condition_type: None,
+            trailing_pct: None,
             expires_at: None,
         };
         let rt = tokio::runtime::Runtime::new().unwrap();
@@ -3017,13 +3025,15 @@ mod tests {
     #[test]
     fn test_create_conditional_order_validation_rejects_nan_limit_price() {
         let params = CreateConditionalOrderParams {
+            market_id: "mkt-1".into(),
             token_id: "tok-1".into(),
+            order_type: "LIMIT".into(),
             side: "BUY".into(),
             outcome: "YES".into(),
             size: 10.0,
             trigger_price: 0.5,
             limit_price: Some(f64::NAN),
-            condition_type: None,
+            trailing_pct: None,
             expires_at: None,
         };
         let rt = tokio::runtime::Runtime::new().unwrap();
@@ -3234,17 +3244,32 @@ mod tests {
             "id": "bt-1",
             "status": "COMPLETED",
             "strategyId": "s1",
-            "createdAt": "2026-04-14T00:00:00Z",
+            "startDate": "2026-01-01T00:00:00Z",
+            "endDate": "2026-03-01T00:00:00Z",
+            "initialBalance": 10000.0,
+            "finalBalance": 10150.5,
             "pnl": 150.5,
-            "tradeCount": 42
+            "tradeCount": 42,
+            "winRate": 0.62,
+            "sharpeRatio": 1.8,
+            "maxDrawdown": 0.05,
+            "createdAt": "2026-04-14T00:00:00Z",
+            "completedAt": "2026-04-14T00:01:00Z"
         }"#;
         let bt: Backtest = serde_json::from_str(json).unwrap();
         assert_eq!(bt.id, "bt-1");
         assert_eq!(bt.status.as_deref(), Some("COMPLETED"));
         assert_eq!(bt.strategy_id.as_deref(), Some("s1"));
+        assert_eq!(bt.start_date.as_deref(), Some("2026-01-01T00:00:00Z"));
+        assert_eq!(bt.end_date.as_deref(), Some("2026-03-01T00:00:00Z"));
+        assert_eq!(bt.initial_balance, Some(10000.0));
+        assert_eq!(bt.final_balance, Some(10150.5));
+        assert_eq!(bt.pnl, Some(150.5));
+        assert_eq!(bt.trade_count, Some(42));
+        assert_eq!(bt.win_rate, Some(0.62));
+        assert_eq!(bt.sharpe_ratio, Some(1.8));
+        assert_eq!(bt.max_drawdown, Some(0.05));
         assert_eq!(bt.created_at.as_deref(), Some("2026-04-14T00:00:00Z"));
-        // Extra fields captured via flatten
-        assert_eq!(bt.extra["pnl"], 150.5);
-        assert_eq!(bt.extra["tradeCount"], 42);
+        assert_eq!(bt.completed_at.as_deref(), Some("2026-04-14T00:01:00Z"));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -143,7 +143,7 @@ pub struct Block {
     #[serde(default)]
     pub config: Option<serde_json::Value>,
     #[serde(default)]
-    pub enabled: Option<bool>,
+    pub connections: Vec<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -342,7 +342,27 @@ pub struct Backtest {
     #[serde(default)]
     pub strategy_id: Option<String>,
     #[serde(default)]
+    pub start_date: Option<String>,
+    #[serde(default)]
+    pub end_date: Option<String>,
+    #[serde(default)]
+    pub initial_balance: Option<f64>,
+    #[serde(default)]
+    pub final_balance: Option<f64>,
+    #[serde(default)]
+    pub pnl: Option<f64>,
+    #[serde(default)]
+    pub trade_count: Option<i64>,
+    #[serde(default)]
+    pub win_rate: Option<f64>,
+    #[serde(default)]
+    pub sharpe_ratio: Option<f64>,
+    #[serde(default)]
+    pub max_drawdown: Option<f64>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
+    pub completed_at: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -1173,7 +1193,10 @@ pub struct ListConditionalOrdersParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateConditionalOrderParams {
+    pub market_id: String,
     pub token_id: String,
+    #[serde(rename = "type")]
+    pub order_type: String,
     pub side: String,
     pub outcome: String,
     pub size: f64,
@@ -1181,7 +1204,7 @@ pub struct CreateConditionalOrderParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit_price: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub condition_type: Option<String>,
+    pub trailing_pct: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
 }


### PR DESCRIPTION
## Summary
- **CreateConditionalOrderParams** (#115): Add required `market_id`, rename `condition_type` → `order_type` (serializes as `type`), add `trailing_pct`
- **Block** (#116): Replace `enabled: Option<bool>` with `connections: Vec<String>` — strategies were losing their block graph on round-trip
- **Backtest** (#117): Add 10 missing fields (`pnl`, `win_rate`, `sharpe_ratio`, `max_drawdown`, `trade_count`, `initial_balance`, `final_balance`, `start_date`, `end_date`, `completed_at`)

## Test plan
- [x] 160 tests + 2 doc-tests pass
- [x] Clippy clean
- [x] Serialization test updated to verify `type` field name and `marketId` presence
- [x] Backtest deserialization test expanded to cover all 14 platform fields

closes #115, closes #116, closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)