### PR TITLE
fix(compat): replace string period with typed PnlPeriod enum (closes #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.4] — 2026-04-15
+
+### Fixed
+- **GetPortfolioPnlParams** — replace `Option<String>` with typed `PnlPeriod` enum. Removes phantom `"1d"` value, renames `"all"` → `"allTime"`, adds missing `"90d"` variant. (closes #120)
+
 ## [1.7.3] — 2026-04-15
 
 ### Fixed

--- a/src/client.rs
+++ b/src/client.rs
@@ -1160,7 +1160,8 @@ impl PolyforgeClient {
     pub async fn get_portfolio_pnl(&self, params: &GetPortfolioPnlParams) -> Result<PortfolioPnl> {
         let mut qp: Vec<(&str, String)> = Vec::new();
         if let Some(ref p) = params.period {
-            qp.push(("period", p.clone()));
+            let val = serde_json::to_value(p).unwrap_or_default();
+            qp.push(("period", val.as_str().unwrap_or_default().to_string()));
         }
         if let Some(ref s) = params.strategy_id {
             qp.push(("strategyId", s.clone()));
@@ -3134,6 +3135,26 @@ mod tests {
         let params = GetPortfolioPnlParams::default();
         assert!(params.period.is_none());
         assert!(params.strategy_id.is_none());
+    }
+
+    #[test]
+    fn test_pnl_period_serializes_correctly() {
+        assert_eq!(
+            serde_json::to_value(PnlPeriod::SevenDays).unwrap(),
+            serde_json::Value::String("7d".to_string())
+        );
+        assert_eq!(
+            serde_json::to_value(PnlPeriod::ThirtyDays).unwrap(),
+            serde_json::Value::String("30d".to_string())
+        );
+        assert_eq!(
+            serde_json::to_value(PnlPeriod::NinetyDays).unwrap(),
+            serde_json::Value::String("90d".to_string())
+        );
+        assert_eq!(
+            serde_json::to_value(PnlPeriod::AllTime).unwrap(),
+            serde_json::Value::String("allTime".to_string())
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1256,11 +1256,24 @@ pub struct PortfolioPnl {
     pub extra: serde_json::Value,
 }
 
+/// Valid periods for portfolio PnL queries.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PnlPeriod {
+    #[serde(rename = "7d")]
+    SevenDays,
+    #[serde(rename = "30d")]
+    ThirtyDays,
+    #[serde(rename = "90d")]
+    NinetyDays,
+    #[serde(rename = "allTime")]
+    AllTime,
+}
+
 /// Parameters for fetching portfolio PnL.
 #[derive(Debug, Default)]
 pub struct GetPortfolioPnlParams {
-    /// Time period: `"1d"`, `"7d"`, `"30d"`, `"all"`.
-    pub period: Option<String>,
+    /// Time period: `"7d"`, `"30d"`, `"90d"`, `"allTime"`.
+    pub period: Option<PnlPeriod>,
     /// Filter by strategy ID.
     pub strategy_id: Option<String>,
 }


### PR DESCRIPTION
## Summary
- Replace `Option<String>` with typed `PnlPeriod` enum on `GetPortfolioPnlParams.period`
- Removes phantom `"1d"` value that causes 422 errors
- Renames `"all"` → `"allTime"` to match platform `PnlQueryDto`
- Adds missing `"90d"` variant
- 161 tests + 2 doc-tests pass

## Test plan
- [x] `test_pnl_period_serializes_correctly` — verifies all 4 enum variants serialize to correct strings
- [x] `test_get_portfolio_pnl_params_default` — existing test still passes

closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)