### PR TITLE
feat(compat): add copy trading CRUD + missing endpoint families

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1033,6 +1033,34 @@ impl PolyforgeClient {
         .await
     }
 
+    /// Rate a purchased marketplace strategy (1–5 stars).
+    pub async fn rate_listing(&self, id: &str, params: &RateListingParams) -> Result<serde_json::Value> {
+        let body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
+        self.post(&format!("/api/v1/marketplace/{}/rate", encode(id)), &body).await
+    }
+
+    /// List your own marketplace listings (sell-side).
+    pub async fn get_my_listings(&self) -> Result<Vec<MarketplaceListing>> {
+        self.get("/api/v1/marketplace/my/listings").await
+    }
+
+    /// List strategies you have purchased from the marketplace.
+    pub async fn get_my_purchases(&self) -> Result<Vec<serde_json::Value>> {
+        self.get("/api/v1/marketplace/my/purchases").await
+    }
+
+    /// Create a new marketplace listing for one of your strategies.
+    pub async fn create_listing(&self, params: &CreateListingParams) -> Result<MarketplaceListing> {
+        let body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
+        self.post("/api/v1/marketplace", &body).await
+    }
+
+    /// Update an existing marketplace listing.
+    pub async fn update_listing(&self, id: &str, params: &UpdateListingParams) -> Result<MarketplaceListing> {
+        let body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
+        self.patch(&format!("/api/v1/marketplace/{}", encode(id)), &body).await
+    }
+
     // -----------------------------------------------------------------------
     // Social & Signals
     // -----------------------------------------------------------------------
@@ -1049,6 +1077,49 @@ impl PolyforgeClient {
         self.get(&format!("/api/v1/whales/feed{qs}")).await
     }
 
+    /// Get top whale wallets ranked by volume, PnL, win rate, or trade count.
+    pub async fn get_top_whales(&self, params: Option<&GetTopWhalesParams>) -> Result<Vec<WhaleProfile>> {
+        let mut qp: Vec<(&str, String)> = Vec::new();
+        if let Some(p) = params {
+            if let Some(ref sort_by) = p.sort_by {
+                qp.push(("sortBy", sort_by.clone()));
+            }
+            if let Some(ref period) = p.period {
+                qp.push(("period", period.clone()));
+            }
+            if let Some(limit) = p.limit {
+                qp.push(("limit", limit.to_string()));
+            }
+        }
+        let qs = if qp.is_empty() {
+            String::new()
+        } else {
+            let pairs: Vec<String> = qp.iter().map(|(k, v)| format!("{}={}", k, encode(v))).collect();
+            format!("?{}", pairs.join("&"))
+        };
+        self.get(&format!("/api/v1/whales/top{qs}")).await
+    }
+
+    /// Get the full trading profile of a specific whale wallet.
+    pub async fn get_whale_profile(&self, address: &str) -> Result<WhaleProfile> {
+        self.get(&format!("/api/v1/whales/{}", encode(address))).await
+    }
+
+    /// Follow a whale wallet to receive alerts when it trades.
+    pub async fn follow_whale(&self, address: &str) -> Result<serde_json::Value> {
+        self.post(&format!("/api/v1/whales/{}/follow", encode(address)), &json!({})).await
+    }
+
+    /// Unfollow a whale wallet.
+    pub async fn unfollow_whale(&self, address: &str) -> Result<serde_json::Value> {
+        self.post(&format!("/api/v1/whales/{}/unfollow", encode(address)), &json!({})).await
+    }
+
+    /// List whale wallets you are currently following.
+    pub async fn get_following_whales(&self) -> Result<Vec<WhaleProfile>> {
+        self.get("/api/v1/whales/following").await
+    }
+
     /// Get AI-powered news signals.
     pub async fn get_news_signals(
         &self,
@@ -1059,6 +1130,70 @@ impl PolyforgeClient {
             None => String::new(),
         };
         self.get(&format!("/api/v1/news/signals{qs}")).await
+    }
+
+    // -----------------------------------------------------------------------
+    // Discover & Leaderboard
+    // -----------------------------------------------------------------------
+
+    /// Discover publicly shared strategies.
+    pub async fn discover_strategies(&self, params: Option<&DiscoverParams>) -> Result<serde_json::Value> {
+        let mut qp: Vec<(&str, String)> = Vec::new();
+        if let Some(p) = params {
+            if let Some(ref sort) = p.sort { qp.push(("sort", sort.clone())); }
+            if let Some(ref category) = p.category { qp.push(("category", category.clone())); }
+            if let Some(ref search) = p.search { qp.push(("search", search.clone())); }
+            if let Some(page) = p.page { qp.push(("page", page.to_string())); }
+            if let Some(limit) = p.limit { qp.push(("limit", limit.to_string())); }
+        }
+        let qs = if qp.is_empty() {
+            String::new()
+        } else {
+            let pairs: Vec<String> = qp.iter().map(|(k, v)| format!("{}={}", k, encode(v))).collect();
+            format!("?{}", pairs.join("&"))
+        };
+        self.get(&format!("/api/v1/discover{qs}")).await
+    }
+
+    /// Get the trader leaderboard ranked by realized P&L.
+    pub async fn get_leaderboard(&self, params: Option<&LeaderboardParams>) -> Result<serde_json::Value> {
+        let mut qp: Vec<(&str, String)> = Vec::new();
+        if let Some(p) = params {
+            if let Some(ref period) = p.period { qp.push(("period", period.clone())); }
+            if let Some(page) = p.page { qp.push(("page", page.to_string())); }
+            if let Some(limit) = p.limit { qp.push(("limit", limit.to_string())); }
+        }
+        let qs = if qp.is_empty() {
+            String::new()
+        } else {
+            let pairs: Vec<String> = qp.iter().map(|(k, v)| format!("{}={}", k, encode(v))).collect();
+            format!("?{}", pairs.join("&"))
+        };
+        self.get(&format!("/api/v1/leaderboard{qs}")).await
+    }
+
+    // -----------------------------------------------------------------------
+    // Paper trading
+    // -----------------------------------------------------------------------
+
+    /// Get a summary of the paper trading account.
+    pub async fn get_paper_summary(&self) -> Result<PaperSummary> {
+        self.get("/api/v1/paper/summary").await
+    }
+
+    /// Reset the paper trading account to its initial balance.
+    pub async fn reset_paper_account(&self) -> Result<serde_json::Value> {
+        self.post("/api/v1/paper/reset", &json!({})).await
+    }
+
+    // -----------------------------------------------------------------------
+    // Batch API
+    // -----------------------------------------------------------------------
+
+    /// Execute multiple API calls in a single round-trip.
+    pub async fn batch_requests(&self, items: &[BatchRequestItem]) -> Result<BatchResponse> {
+        let body = json!({ "items": items });
+        self.post("/api/v1/batch", &body).await
     }
 
     // -----------------------------------------------------------------------
@@ -1073,6 +1208,62 @@ impl PolyforgeClient {
     /// List copy-trading configurations.
     pub async fn list_copy_configs(&self) -> Result<PaginatedResponse<CopyConfig>> {
         self.get("/api/v1/copy").await
+    }
+
+    /// Create a new copy trading configuration.
+    pub async fn create_copy_config(&self, params: &CreateCopyConfigParams) -> Result<CopyConfig> {
+        let body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
+        self.post("/api/v1/copy", &body).await
+    }
+
+    /// Get a single copy trading configuration by ID.
+    pub async fn get_copy_config(&self, id: &str) -> Result<CopyConfig> {
+        self.get(&format!("/api/v1/copy/{}", encode(id))).await
+    }
+
+    /// Update an existing copy trading configuration.
+    pub async fn update_copy_config(&self, id: &str, params: &UpdateCopyConfigParams) -> Result<CopyConfig> {
+        let body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
+        self.patch(&format!("/api/v1/copy/{}", encode(id)), &body).await
+    }
+
+    /// Pause a copy trading configuration.
+    pub async fn pause_copy_config(&self, id: &str) -> Result<CopyConfig> {
+        self.post(&format!("/api/v1/copy/{}/pause", encode(id)), &json!({})).await
+    }
+
+    /// Resume a paused copy trading configuration.
+    pub async fn resume_copy_config(&self, id: &str) -> Result<CopyConfig> {
+        self.post(&format!("/api/v1/copy/{}/resume", encode(id)), &json!({})).await
+    }
+
+    /// Delete (stop) a copy trading configuration.
+    pub async fn delete_copy_config(&self, id: &str) -> Result<serde_json::Value> {
+        self.delete(&format!("/api/v1/copy/{}", encode(id))).await
+    }
+
+    /// Get trades executed by a copy trading configuration.
+    pub async fn get_copy_trades(
+        &self,
+        id: &str,
+        params: Option<&GetCopyTradesParams>,
+    ) -> Result<PaginatedResponse<Order>> {
+        let mut qp: Vec<(&str, String)> = Vec::new();
+        if let Some(p) = params {
+            if let Some(page) = p.page {
+                qp.push(("page", page.to_string()));
+            }
+            if let Some(limit) = p.limit {
+                qp.push(("limit", limit.to_string()));
+            }
+        }
+        let qs = if qp.is_empty() {
+            String::new()
+        } else {
+            let pairs: Vec<String> = qp.iter().map(|(k, v)| format!("{}={}", k, encode(v))).collect();
+            format!("?{}", pairs.join("&"))
+        };
+        self.get(&format!("/api/v1/copy/{}/trades{qs}", encode(id))).await
     }
 
     /// List registered webhooks.
@@ -3408,5 +3599,148 @@ mod tests {
         assert_eq!(bt.max_drawdown, Some(0.05));
         assert_eq!(bt.created_at.as_deref(), Some("2026-04-14T00:00:00Z"));
         assert_eq!(bt.completed_at.as_deref(), Some("2026-04-14T00:01:00Z"));
+    }
+
+    // ── Copy trading CRUD (#51) ───────────────────────────────────────────────
+
+    #[test]
+    fn test_create_copy_config_params_serializes_target_wallet() {
+        let params = CreateCopyConfigParams {
+            target_wallet: "0xabcdef1234567890abcdef1234567890abcdef12".to_string(),
+            mode: Some(CopyMode::Percentage),
+            ..Default::default()
+        };
+        let body = serde_json::to_value(&params).unwrap();
+        assert_eq!(body["targetWallet"], "0xabcdef1234567890abcdef1234567890abcdef12");
+        assert_eq!(body["mode"], "PERCENTAGE");
+    }
+
+    #[test]
+    fn test_update_copy_config_params_skips_none_fields() {
+        let params = UpdateCopyConfigParams {
+            size_value: Some("100".to_string()),
+            ..Default::default()
+        };
+        let body = serde_json::to_value(&params).unwrap();
+        assert!(body.get("sizeValue").is_some());
+        // None fields should be absent due to skip_serializing_if
+        assert!(body.get("mode").is_none());
+        assert!(body.get("maxExposure").is_none());
+    }
+
+    #[test]
+    fn test_get_copy_trades_params_default() {
+        let params = GetCopyTradesParams::default();
+        assert!(params.page.is_none());
+        assert!(params.limit.is_none());
+    }
+
+    // ── Whale extended (#66) ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_whale_profile_deserializes() {
+        let json = r#"{
+            "walletAddress": "0xabc",
+            "stats": {
+                "totalVolume": "10000",
+                "totalPnl": "500",
+                "tradeCount": 42,
+                "winRate": "0.62"
+            },
+            "recentTrades": [],
+            "sparkline": [0, 1, 2],
+            "isFollowing": true
+        }"#;
+        let profile: WhaleProfile = serde_json::from_str(json).unwrap();
+        assert_eq!(profile.wallet_address, "0xabc");
+        assert!(profile.stats.is_some());
+        assert!(profile.is_following);
+        assert_eq!(profile.sparkline, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_get_top_whales_params_default() {
+        let params = GetTopWhalesParams::default();
+        assert!(params.sort_by.is_none());
+        assert!(params.period.is_none());
+        assert!(params.limit.is_none());
+    }
+
+    // ── Paper trading (#66) ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_paper_summary_deserializes() {
+        let json = r#"{"balance": 10000.0, "pnl": 500.0, "tradeCount": 12, "openPositions": 3}"#;
+        let summary: PaperSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(summary.balance, 10000.0);
+        assert_eq!(summary.pnl, 500.0);
+        assert_eq!(summary.trade_count, 12);
+        assert_eq!(summary.open_positions, 3);
+    }
+
+    // ── Batch API (#66) ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_batch_request_item_serializes() {
+        let item = BatchRequestItem {
+            method: "GET".to_string(),
+            path: "/api/v1/portfolio".to_string(),
+            body: None,
+        };
+        let val = serde_json::to_value(&item).unwrap();
+        assert_eq!(val["method"], "GET");
+        assert_eq!(val["path"], "/api/v1/portfolio");
+        // body is None — skip_serializing_if should omit it
+        assert!(val.get("body").is_none());
+    }
+
+    #[test]
+    fn test_batch_response_deserializes() {
+        let json = r#"{"results":[{"status":200,"body":{"ok":true}}]}"#;
+        let resp: BatchResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.results.len(), 1);
+        assert_eq!(resp.results[0].status, 200);
+    }
+
+    // ── Marketplace seller (#66) ─────────────────────────────────────────────
+
+    #[test]
+    fn test_create_listing_params_serializes() {
+        let params = CreateListingParams {
+            strategy_id: "strat-1".to_string(),
+            title: "My Strategy".to_string(),
+            description: None,
+            price_usdc: 10.0,
+            tags: Some(vec!["algo".to_string()]),
+        };
+        let body = serde_json::to_value(&params).unwrap();
+        assert_eq!(body["strategyId"], "strat-1");
+        assert_eq!(body["title"], "My Strategy");
+        assert_eq!(body["priceUsdc"], 10.0);
+        assert!(body.get("description").is_none());
+        assert_eq!(body["tags"][0], "algo");
+    }
+
+    #[test]
+    fn test_update_listing_params_skips_none_fields() {
+        let params = UpdateListingParams {
+            status: Some("PAUSED".to_string()),
+            ..Default::default()
+        };
+        let body = serde_json::to_value(&params).unwrap();
+        assert_eq!(body["status"], "PAUSED");
+        assert!(body.get("title").is_none());
+        assert!(body.get("priceUsdc").is_none());
+    }
+
+    #[test]
+    fn test_rate_listing_params_serializes() {
+        let params = RateListingParams {
+            rating: 5,
+            review: Some("Excellent!".to_string()),
+        };
+        let body = serde_json::to_value(&params).unwrap();
+        assert_eq!(body["rating"], 5);
+        assert_eq!(body["review"], "Excellent!");
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1294,6 +1294,199 @@ pub struct GetPortfolioPnlParams {
 }
 
 // ---------------------------------------------------------------------------
+// Copy trading CRUD params
+// ---------------------------------------------------------------------------
+
+/// Parameters for creating a copy trading configuration.
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateCopyConfigParams {
+    /// Ethereum wallet address to copy (0x…40 hex chars).
+    pub target_wallet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<CopyMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_exposure: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_daily_loss: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price_offset: Option<String>,
+}
+
+/// Parameters for updating a copy trading configuration.
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateCopyConfigParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<CopyMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_exposure: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_daily_loss: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price_offset: Option<String>,
+}
+
+/// Parameters for fetching trades of a copy config.
+#[derive(Debug, Default)]
+pub struct GetCopyTradesParams {
+    pub page: Option<u32>,
+    pub limit: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// Whale extended types
+// ---------------------------------------------------------------------------
+
+/// Statistics for a whale wallet.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct WhaleStats {
+    #[serde(default)]
+    pub total_volume: String,
+    #[serde(default)]
+    pub total_pnl: String,
+    #[serde(default)]
+    pub trade_count: u64,
+    #[serde(default)]
+    pub win_rate: String,
+}
+
+/// Full trading profile for a whale wallet.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct WhaleProfile {
+    pub wallet_address: String,
+    #[serde(default)]
+    pub stats: Option<WhaleStats>,
+    #[serde(default)]
+    pub recent_trades: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub sparkline: Vec<u64>,
+    #[serde(default)]
+    pub is_following: bool,
+}
+
+/// Parameters for fetching top whale wallets.
+#[derive(Debug, Default)]
+pub struct GetTopWhalesParams {
+    pub sort_by: Option<String>,
+    pub period: Option<String>,
+    pub limit: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// Discover & Leaderboard params
+// ---------------------------------------------------------------------------
+
+/// Parameters for the strategy discover endpoint.
+#[derive(Debug, Default)]
+pub struct DiscoverParams {
+    pub sort: Option<String>,
+    pub category: Option<String>,
+    pub search: Option<String>,
+    pub page: Option<u32>,
+    pub limit: Option<u32>,
+}
+
+/// Parameters for the leaderboard endpoint.
+#[derive(Debug, Default)]
+pub struct LeaderboardParams {
+    pub period: Option<String>,
+    pub page: Option<u32>,
+    pub limit: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// Paper trading
+// ---------------------------------------------------------------------------
+
+/// Summary of the paper trading account.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PaperSummary {
+    #[serde(default)]
+    pub balance: f64,
+    #[serde(default)]
+    pub pnl: f64,
+    #[serde(default)]
+    pub trade_count: u64,
+    #[serde(default)]
+    pub open_positions: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Batch API
+// ---------------------------------------------------------------------------
+
+/// A single request item in a batch call.
+#[derive(Debug, Serialize)]
+pub struct BatchRequestItem {
+    pub method: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<serde_json::Value>,
+}
+
+/// Response from a batch API call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchResponse {
+    pub results: Vec<BatchResultItem>,
+}
+
+/// Individual result within a batch response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchResultItem {
+    pub status: u16,
+    pub body: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace seller params
+// ---------------------------------------------------------------------------
+
+/// Parameters for creating a marketplace listing.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateListingParams {
+    pub strategy_id: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub price_usdc: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+}
+
+/// Parameters for updating a marketplace listing.
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateListingParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price_usdc: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+/// Parameters for rating a marketplace listing.
+#[derive(Debug, Serialize)]
+pub struct RateListingParams {
+    pub rating: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
 // Strategy Execution Events (SSE)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add 7 copy trading CRUD methods (`create_copy_config`, `get_copy_config`, `update_copy_config`, `pause_copy_config`, `resume_copy_config`, `delete_copy_config`, `get_copy_trades`)
- Add discover/leaderboard endpoints (`discover_strategies`, `get_leaderboard`)
- Add paper trading endpoints (`get_paper_summary`, `reset_paper_account`)
- Add batch API (`batch_requests`)
- Add extended whale intelligence (`get_top_whales`, `get_whale_profile`, `follow_whale`, `unfollow_whale`, `get_following_whales`)
- Add marketplace seller CRUD (`create_listing`, `update_listing`, `rate_listing`, `get_my_listings`, `get_my_purchases`)
- Add 15 new types with proper serde derives and `skip_serializing_if = "Option::is_none"` for optional fields

Closes #69

## Test plan

- [ ] 11 new unit tests for type serialization of all new param structs
- [ ] All 174 unit tests pass (`cargo test`)
- [ ] All 4 doc-tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)