### PR TITLE
fix(security): bump rustls-webpki 0.103.11 → 0.103.12 (RUSTSEC-2026-0098, RUSTSEC-2026-0099)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Updates `rustls-webpki` from `0.103.11` to `0.103.12` to resolve two name constraint bypass vulnerabilities:
- **RUSTSEC-2026-0098** — name constraint bypass in rustls-webpki
- **RUSTSEC-2026-0099** — related name constraint bypass

This is a `Cargo.lock`-only update (`cargo update rustls-webpki`). No source changes required.

Closes #128.

## Test plan

- [x] `cargo test` — 174 unit tests + 4 doc-tests pass
- [x] No API surface changes