### PR TITLE
fix(compat): nest PaginatedResponse pagination fields under pagination object (#142)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2726,20 +2726,15 @@ mod tests {
 
     #[test]
     fn test_paginated_response_deserializes_strategies() {
-        // #76: List endpoints return PaginatedResponse, not Vec
+        // #76 / #142: PaginatedResponse uses nested pagination object matching platform contract
         let json = r#"{
             "data": [{"id":"s1","name":"Alpha"},{"id":"s2","name":"Beta"}],
-            "total": 2,
-            "page": 1,
-            "limit": 10,
-            "totalPages": 1,
-            "hasNext": false
+            "pagination": {"page": 1, "limit": 10, "total": 2, "totalPages": 1}
         }"#;
         let resp: PaginatedResponse<Strategy> = serde_json::from_str(json).unwrap();
         assert_eq!(resp.data.len(), 2);
-        assert_eq!(resp.total, 2);
-        assert_eq!(resp.page, 1);
-        assert!(!resp.has_next);
+        assert_eq!(resp.pagination.total, 2);
+        assert_eq!(resp.pagination.page, 1);
         assert_eq!(resp.data[0].id, "s1");
     }
 
@@ -3687,16 +3682,12 @@ mod tests {
     fn test_paginated_conditional_orders_deserializes() {
         let json = r#"{
             "data": [{"id": "co-1"}, {"id": "co-2"}],
-            "total": 2,
-            "page": 1,
-            "limit": 10,
-            "totalPages": 1,
-            "hasNext": false
+            "pagination": {"page": 1, "limit": 10, "total": 2, "totalPages": 1}
         }"#;
         let resp: PaginatedResponse<ConditionalOrder> = serde_json::from_str(json).unwrap();
         assert_eq!(resp.data.len(), 2);
         assert_eq!(resp.data[0].id, "co-1");
-        assert_eq!(resp.total, 2);
+        assert_eq!(resp.pagination.total, 2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! async fn main() -> polyforge::Result<()> {
 //!     let client = PolyforgeClient::new("your-api-key")?;
 //!     let markets = client.list_markets(&Default::default()).await?;
-//!     println!("Found {} markets", markets.total);
+//!     println!("Found {} markets", markets.pagination.total);
 //!     Ok(())
 //! }
 //! ```

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,21 +4,21 @@ use serde::{Deserialize, Serialize};
 // Paginated wrapper
 // ---------------------------------------------------------------------------
 
-/// A paginated API response.
+/// Pagination metadata nested under the `pagination` key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct Pagination {
+    pub page: u64,
+    pub limit: u64,
+    pub total: u64,
+    pub total_pages: u64,
+}
+
+/// A paginated API response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaginatedResponse<T> {
     pub data: Vec<T>,
-    #[serde(default)]
-    pub total: u64,
-    #[serde(default)]
-    pub page: u64,
-    #[serde(default)]
-    pub limit: u64,
-    #[serde(rename = "totalPages", default)]
-    pub total_pages: u64,
-    #[serde(rename = "hasNext", default)]
-    pub has_next: bool,
+    pub pagination: Pagination,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Platform wraps pagination metadata under a nested `pagination` sub-object; SDK had flat top-level fields that always deserialized to zero defaults, silently breaking all paginated endpoints
- Adds a `Pagination` struct (`page`, `limit`, `total`, `total_pages` with `camelCase` serde renames) and replaces flat fields on `PaginatedResponse<T>` with `pub pagination: Pagination`
- Removes the non-existent `has_next` field
- Updates deserialization tests and lib.rs doc-example

Fixes: POLA-364 / GitHub issue #142

## Test plan

- [x] `cargo test` — 181 unit tests + 4 doc-tests all pass
- [x] Both `test_paginated_response_deserializes_strategies` and `test_paginated_conditional_orders_deserializes` updated to use nested shape
- [x] `test_paginated_response_rejects_bare_array` unchanged — still guards against bare array regression

🤖 Generated with [Claude Code](https://claude.ai/claude-code)