### PR TITLE
fix(compat): replace TradingMode with StartStrategyParams for start_strategy (#145)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -637,14 +637,17 @@ impl PolyforgeClient {
 
     /// Start a strategy in the given trading mode.
     ///
+    /// Accepts a [`StartStrategyParams`] or anything that converts into one
+    /// (e.g. `TradingMode::Live.into()`).
+    ///
     /// Returns a [`StrategyStatusResponse`] with the new status and `startedAt`
     /// timestamp — not a full [`Strategy`] object.
     pub async fn start_strategy(
         &self,
         id: &str,
-        mode: TradingMode,
+        params: impl Into<StartStrategyParams>,
     ) -> Result<StrategyStatusResponse> {
-        let body = json!({ "mode": mode });
+        let body = serde_json::to_value(params.into())?;
         self.post(&format!("/api/v1/strategies/{}/start", encode(id)), &body)
             .await
     }
@@ -2430,15 +2433,50 @@ mod tests {
         }
     }
 
-    // --- Platform contract compliance regression tests (#89-#92) ---
+    // --- Platform contract compliance regression tests (#89-#92, #145) ---
 
     #[test]
     fn test_trading_mode_serializes_lowercase() {
-        // #92: Platform expects "live"/"paper", not "LIVE"/"PAPER"
+        // #92: TradingMode still deserializes from Strategy response fields
         let live = serde_json::to_value(TradingMode::Live).unwrap();
         assert_eq!(live, serde_json::Value::String("live".to_string()));
         let paper = serde_json::to_value(TradingMode::Paper).unwrap();
         assert_eq!(paper, serde_json::Value::String("paper".to_string()));
+    }
+
+    #[test]
+    fn test_start_strategy_params_serializes_platform_contract() {
+        // #145: start_strategy must send {paperMode, deploymentMode}, not {mode}
+        let live = serde_json::to_value(StartStrategyParams::live()).unwrap();
+        assert_eq!(live["paperMode"], serde_json::Value::Bool(false));
+        assert_eq!(live["deploymentMode"], serde_json::Value::String("LIVE".to_string()));
+        assert!(live.get("mode").is_none(), "legacy 'mode' field must not be present");
+
+        let paper = serde_json::to_value(StartStrategyParams::paper()).unwrap();
+        assert_eq!(paper["paperMode"], serde_json::Value::Bool(true));
+        assert_eq!(paper["deploymentMode"], serde_json::Value::String("SIMULATION".to_string()));
+        assert!(paper.get("mode").is_none(), "legacy 'mode' field must not be present");
+    }
+
+    #[test]
+    fn test_trading_mode_converts_to_start_strategy_params() {
+        // #145: TradingMode::into() must produce correct StartStrategyParams
+        let params: StartStrategyParams = TradingMode::Live.into();
+        assert!(!params.paper_mode);
+        assert_eq!(params.deployment_mode.as_deref(), Some("LIVE"));
+
+        let params: StartStrategyParams = TradingMode::Paper.into();
+        assert!(params.paper_mode);
+        assert_eq!(params.deployment_mode.as_deref(), Some("SIMULATION"));
+    }
+
+    #[test]
+    fn test_start_strategy_params_no_deployment_mode_omitted() {
+        // deployment_mode is optional — omit when None
+        let params = StartStrategyParams { paper_mode: false, deployment_mode: None };
+        let v = serde_json::to_value(&params).unwrap();
+        assert_eq!(v["paperMode"], serde_json::Value::Bool(false));
+        assert!(v.get("deploymentMode").is_none());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -185,6 +185,38 @@ pub enum TradingMode {
     Paper,
 }
 
+/// Request body for `POST /api/v1/strategies/{id}/start`.
+///
+/// The platform expects `paperMode` + optional `deploymentMode`, not the legacy
+/// `mode` string. Use [`StartStrategyParams::live`] / [`StartStrategyParams::paper`]
+/// or construct directly. `TradingMode` converts into this via `From`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StartStrategyParams {
+    pub paper_mode: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_mode: Option<String>,
+}
+
+impl StartStrategyParams {
+    pub fn live() -> Self {
+        Self { paper_mode: false, deployment_mode: Some("LIVE".to_string()) }
+    }
+
+    pub fn paper() -> Self {
+        Self { paper_mode: true, deployment_mode: Some("SIMULATION".to_string()) }
+    }
+}
+
+impl From<TradingMode> for StartStrategyParams {
+    fn from(mode: TradingMode) -> Self {
+        match mode {
+            TradingMode::Live => Self::live(),
+            TradingMode::Paper => Self::paper(),
+        }
+    }
+}
+
 /// A trading strategy.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Summary

- Platform `POST /api/v1/strategies/{id}/start` expects `{paperMode: bool, deploymentMode?: string}`, not `{mode: string}`
- Old code sent `{mode: "live"}` / `{mode: "paper"}` — the `mode` field is ignored by the platform, silently defaulting all strategies to live mode regardless of user intent (critical: users calling `TradingMode::Paper` would execute real orders)
- Added `StartStrategyParams` struct with correct field names; `start_strategy` now accepts `impl Into<StartStrategyParams>` so existing callers using `TradingMode` still compile via `From`

## Test plan

- [x] `test_start_strategy_params_serializes_platform_contract` — verifies `{paperMode, deploymentMode}` are present and `mode` is absent
- [x] `test_trading_mode_converts_to_start_strategy_params` — verifies `TradingMode::into()` produces correct params
- [x] `test_start_strategy_params_no_deployment_mode_omitted` — verifies `deploymentMode` is omitted when `None`
- [x] All 184 tests pass

Fixes POLA-361

🤖 Generated with [Claude Code](https://claude.com/claude-code)