### PR TITLE
fix(compat): add missing id field to batch types (POLA-357)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -4134,22 +4134,24 @@ mod tests {
     #[test]
     fn test_batch_request_item_serializes() {
         let item = BatchRequestItem {
+            id: "req-1".to_string(),
             method: "GET".to_string(),
             path: "/api/v1/portfolio".to_string(),
             body: None,
         };
         let val = serde_json::to_value(&item).unwrap();
+        assert_eq!(val["id"], "req-1");
         assert_eq!(val["method"], "GET");
         assert_eq!(val["path"], "/api/v1/portfolio");
-        // body is None — skip_serializing_if should omit it
         assert!(val.get("body").is_none());
     }
 
     #[test]
     fn test_batch_response_deserializes() {
-        let json = r#"{"results":[{"status":200,"body":{"ok":true}}]}"#;
+        let json = r#"{"results":[{"id":"req-1","status":200,"body":{"ok":true}}]}"#;
         let resp: BatchResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.results.len(), 1);
+        assert_eq!(resp.results[0].id, "req-1");
         assert_eq!(resp.results[0].status, 200);
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1502,6 +1502,7 @@ pub struct PaperSummary {
 /// A single request item in a batch call.
 #[derive(Debug, Serialize)]
 pub struct BatchRequestItem {
+    pub id: String,
     pub method: String,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1517,6 +1518,7 @@ pub struct BatchResponse {
 /// Individual result within a batch response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatchResultItem {
+    pub id: String,
     pub status: u16,
     pub body: serde_json::Value,
 }


### PR DESCRIPTION
## Summary
- Add required `id: String` field to `BatchRequestItem` — the platform requires a client-assigned correlation ID on each sub-request
- Add `id: String` field to `BatchResultItem` — the platform echoes the correlation ID back in results
- Update existing tests to include `id` in serialization and deserialization assertions

Aligns sdk-rust with sdk-python which already has the `id` field on `BatchResult`.

Closes #151

## Test plan
- [x] `test_batch_request_item_serializes` — verifies `id` is serialized
- [x] `test_batch_response_deserializes` — verifies `id` is deserialized from platform response
- [x] Full test suite: 187 unit tests + 4 doc-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)