### PR TITLE
fix(compat): rewrite CopyConfig to strategy-based model (POLA-360)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3033,34 +3033,30 @@ mod tests {
 
     #[test]
     fn test_copy_config_deserializes_platform_fields() {
-        // #51: CopyConfig must use targetWallet, mode, maxExposure etc.
+        // #146: CopyConfig must use strategy-based model (sourceStrategyId, allocationPercent)
         let json = r#"{
             "id": "cc1",
-            "targetWallet": "0xabc123",
-            "mode": "PERCENTAGE",
-            "sizeValue": "50",
-            "maxExposure": "1000",
-            "maxDailyLoss": "100",
-            "priceOffset": "0.01",
+            "sourceStrategyId": "strat-uuid-abc",
+            "name": "My Copy",
+            "allocationPercent": 50,
+            "initialBalance": "1000",
             "enabled": true
         }"#;
         let config: CopyConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.target_wallet, Some("0xabc123".to_string()));
-        assert_eq!(config.mode, Some(CopyMode::Percentage));
-        assert_eq!(config.size_value, Some("50".to_string()));
-        assert_eq!(config.max_exposure, Some("1000".to_string()));
-        assert_eq!(config.max_daily_loss, Some("100".to_string()));
-        assert_eq!(config.price_offset, Some("0.01".to_string()));
+        assert_eq!(config.source_strategy_id, Some("strat-uuid-abc".to_string()));
+        assert_eq!(config.name, Some("My Copy".to_string()));
+        assert_eq!(config.allocation_percent, Some(50));
+        assert_eq!(config.initial_balance, Some("1000".to_string()));
         assert_eq!(config.enabled, Some(true));
     }
 
     #[test]
-    fn test_copy_config_no_source_trader_field() {
-        // #51: Verify that the old source_trader field name does NOT work
-        let json = r#"{"id":"cc1","sourceTrader":"0xabc"}"#;
+    fn test_copy_config_wallet_fields_go_to_extra() {
+        // #146: Old wallet-based fields must NOT map to named fields
+        let json = r#"{"id":"cc1","targetWallet":"0xabc","mode":"PERCENTAGE"}"#;
         let config: CopyConfig = serde_json::from_str(json).unwrap();
-        // sourceTrader goes into extra, not target_wallet
-        assert_eq!(config.target_wallet, None);
+        assert!(config.source_strategy_id.is_none());
+        assert!(config.allocation_percent.is_none());
     }
 
     #[test]
@@ -3125,16 +3121,6 @@ mod tests {
         assert_eq!(serde_json::to_value(ExecMode::Tick).unwrap(), "TICK");
         assert_eq!(serde_json::to_value(ExecMode::Event).unwrap(), "EVENT");
         assert_eq!(serde_json::to_value(ExecMode::Hybrid).unwrap(), "HYBRID");
-    }
-
-    #[test]
-    fn test_copy_mode_enum_serializes() {
-        assert_eq!(
-            serde_json::to_value(CopyMode::Percentage).unwrap(),
-            "PERCENTAGE"
-        );
-        assert_eq!(serde_json::to_value(CopyMode::Fixed).unwrap(), "FIXED");
-        assert_eq!(serde_json::to_value(CopyMode::Mirror).unwrap(), "MIRROR");
     }
 
     // -----------------------------------------------------------------------
@@ -4052,31 +4038,31 @@ mod tests {
     // ── Copy trading CRUD (#51) ───────────────────────────────────────────────
 
     #[test]
-    fn test_create_copy_config_params_serializes_target_wallet() {
+    fn test_create_copy_config_params_serializes_strategy_fields() {
+        // #146: CreateCopyConfigParams must send sourceStrategyId, not targetWallet
         let params = CreateCopyConfigParams {
-            target_wallet: "0xabcdef1234567890abcdef1234567890abcdef12".to_string(),
-            mode: Some(CopyMode::Percentage),
+            source_strategy_id: "strat-uuid-123".to_string(),
+            name: Some("My Copy".to_string()),
+            allocation_percent: Some(50),
             ..Default::default()
         };
         let body = serde_json::to_value(&params).unwrap();
-        assert_eq!(
-            body["targetWallet"],
-            "0xabcdef1234567890abcdef1234567890abcdef12"
-        );
-        assert_eq!(body["mode"], "PERCENTAGE");
+        assert_eq!(body["sourceStrategyId"], "strat-uuid-123");
+        assert_eq!(body["name"], "My Copy");
+        assert_eq!(body["allocationPercent"], 50);
+        assert!(body.get("targetWallet").is_none());
     }
 
     #[test]
     fn test_update_copy_config_params_skips_none_fields() {
         let params = UpdateCopyConfigParams {
-            size_value: Some("100".to_string()),
+            allocation_percent: Some(75),
             ..Default::default()
         };
         let body = serde_json::to_value(&params).unwrap();
-        assert!(body.get("sizeValue").is_some());
+        assert_eq!(body["allocationPercent"], 75);
         // None fields should be absent due to skip_serializing_if
-        assert!(body.get("mode").is_none());
-        assert!(body.get("maxExposure").is_none());
+        assert!(body.get("name").is_none());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -655,38 +655,21 @@ pub struct Alert {
     pub extra: serde_json::Value,
 }
 
-/// Copy trading mode.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum CopyMode {
-    Percentage,
-    Fixed,
-    Mirror,
-}
-
-/// A copy-trading configuration.
+/// A copy-trading configuration (strategy-based).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CopyConfig {
     pub id: String,
-    /// The Ethereum wallet address to copy trades to.
+    /// The strategy being copied.
     #[serde(default)]
-    pub target_wallet: Option<String>,
-    /// Copy mode: PERCENTAGE, FIXED, or MIRROR.
+    pub source_strategy_id: Option<String>,
     #[serde(default)]
-    pub mode: Option<CopyMode>,
-    /// Size value used with the selected mode.
+    pub name: Option<String>,
+    /// Allocation as a percentage (0–100).
     #[serde(default)]
-    pub size_value: Option<String>,
-    /// Maximum exposure as a number string.
+    pub allocation_percent: Option<u8>,
     #[serde(default)]
-    pub max_exposure: Option<String>,
-    /// Maximum daily loss as a number string.
-    #[serde(default)]
-    pub max_daily_loss: Option<String>,
-    /// Price offset as a number string.
-    #[serde(default)]
-    pub price_offset: Option<String>,
+    pub initial_balance: Option<String>,
     #[serde(default)]
     pub enabled: Option<bool>,
     #[serde(flatten)]
@@ -1345,22 +1328,17 @@ pub struct GetPortfolioPnlParams {
 // Copy trading CRUD params
 // ---------------------------------------------------------------------------
 
-/// Parameters for creating a copy trading configuration.
+/// Parameters for creating a copy trading configuration (platform contract).
 #[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateCopyConfigParams {
-    /// Ethereum wallet address to copy (0x…40 hex chars).
-    pub target_wallet: String,
+    pub source_strategy_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<CopyMode>,
+    pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub size_value: Option<String>,
+    pub initial_balance: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_exposure: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_daily_loss: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_offset: Option<String>,
+    pub allocation_percent: Option<u8>,
 }
 
 /// Parameters for updating a copy trading configuration.
@@ -1368,15 +1346,9 @@ pub struct CreateCopyConfigParams {
 #[serde(rename_all = "camelCase")]
 pub struct UpdateCopyConfigParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<CopyMode>,
+    pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub size_value: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_exposure: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_daily_loss: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_offset: Option<String>,
+    pub allocation_percent: Option<u8>,
 }
 
 /// Parameters for fetching trades of a copy config.


### PR DESCRIPTION
## Summary

- **Issue:** [POLA-360](/POLA/issues/POLA-360) — sdk-rust `CopyConfig` used wallet-based fields that don't exist on the platform
- Platform contract for copy trading uses `sourceStrategyId` + `allocationPercent`, not `targetWallet` / `CopyMode` / `sizeValue`
- All copy trading operations were failing because required fields were missing from the request payload

## Changes

- Removed `CopyMode` enum (not in platform contract)
- Rewrote `CopyConfig` response type: `sourceStrategyId`, `name`, `allocationPercent`, `initialBalance`, `enabled`
- Rewrote `CreateCopyConfigParams`: `source_strategy_id` (required), `name`, `initial_balance`, `allocation_percent`
- Rewrote `UpdateCopyConfigParams`: `name`, `allocation_percent`
- Updated all affected tests — 187 pass, 0 fail

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — 187 passed, 0 failed
- [x] New test `test_copy_config_deserializes_platform_fields` verifies strategy fields deserialize correctly
- [x] New test `test_copy_config_wallet_fields_go_to_extra` verifies old wallet fields don't crash deserialization (land in `extra`)
- [x] `test_create_copy_config_params_serializes_strategy_fields` verifies `sourceStrategyId` is sent and `targetWallet` is absent

Fixes: F4CTE/polyforge-sdk-rust#146

🤖 Generated with [Claude Code](https://claude.com/claude-code)