### PR TITLE
fix(compat): start_strategy sends paperMode/deploymentMode (closes #145)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -635,16 +635,19 @@ impl PolyforgeClient {
             .await
     }
 
-    /// Start a strategy in the given trading mode.
+    /// Start a strategy.
+    ///
+    /// Pass [`StartStrategyParams::paper()`] or [`StartStrategyParams::live()`]
+    /// for the common cases, or build a struct directly for fine-grained control.
     ///
     /// Returns a [`StrategyStatusResponse`] with the new status and `startedAt`
     /// timestamp — not a full [`Strategy`] object.
     pub async fn start_strategy(
         &self,
         id: &str,
-        mode: TradingMode,
+        params: StartStrategyParams,
     ) -> Result<StrategyStatusResponse> {
-        let body = json!({ "mode": mode });
+        let body = serde_json::to_value(&params)?;
         self.post(&format!("/api/v1/strategies/{}/start", encode(id)), &body)
             .await
     }
@@ -2549,15 +2552,60 @@ mod tests {
         }
     }
 
-    // --- Platform contract compliance regression tests (#89-#92) ---
+    // --- Platform contract compliance regression tests (#89-#92, #145) ---
 
     #[test]
     fn test_trading_mode_serializes_lowercase() {
-        // #92: Platform expects "live"/"paper", not "LIVE"/"PAPER"
+        // #92: TradingMode is still used when *reading* Strategy.mode from responses.
         let live = serde_json::to_value(TradingMode::Live).unwrap();
         assert_eq!(live, serde_json::Value::String("live".to_string()));
         let paper = serde_json::to_value(TradingMode::Paper).unwrap();
         assert_eq!(paper, serde_json::Value::String("paper".to_string()));
+    }
+
+    #[test]
+    fn test_start_strategy_paper_payload() {
+        // #145: start_strategy must send { paperMode: true } not { mode: "paper" }
+        let body = serde_json::to_value(StartStrategyParams::paper()).unwrap();
+        assert_eq!(body["paperMode"], serde_json::Value::Bool(true));
+        assert!(body.get("mode").is_none(), "must not send legacy `mode` field");
+        assert!(
+            body.get("deploymentMode").is_none(),
+            "deploymentMode must be absent when None"
+        );
+    }
+
+    #[test]
+    fn test_start_strategy_live_payload() {
+        // #145: start_strategy must send { paperMode: false } not { mode: "live" }
+        let body = serde_json::to_value(StartStrategyParams::live()).unwrap();
+        assert_eq!(body["paperMode"], serde_json::Value::Bool(false));
+        assert!(body.get("mode").is_none(), "must not send legacy `mode` field");
+    }
+
+    #[test]
+    fn test_start_strategy_with_deployment_mode() {
+        // #145: DeploymentMode serializes as uppercase "LIVE" / "SIMULATION"
+        let params = StartStrategyParams {
+            paper_mode: false,
+            deployment_mode: Some(DeploymentMode::Live),
+        };
+        let body = serde_json::to_value(&params).unwrap();
+        assert_eq!(body["paperMode"], serde_json::Value::Bool(false));
+        assert_eq!(
+            body["deploymentMode"],
+            serde_json::Value::String("LIVE".to_string())
+        );
+
+        let sim = StartStrategyParams {
+            paper_mode: true,
+            deployment_mode: Some(DeploymentMode::Simulation),
+        };
+        let body2 = serde_json::to_value(&sim).unwrap();
+        assert_eq!(
+            body2["deploymentMode"],
+            serde_json::Value::String("SIMULATION".to_string())
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -174,13 +174,48 @@ pub struct CalcBlock {
     pub extra: serde_json::Value,
 }
 
-/// Trading mode used when starting a strategy.
+/// Trading mode read from a strategy response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TradingMode {
     #[serde(rename = "live")]
     Live,
     #[serde(rename = "paper")]
     Paper,
+}
+
+/// Deployment mode sent when starting a strategy.
+///
+/// Platform contract: `"LIVE"` or `"SIMULATION"`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DeploymentMode {
+    #[serde(rename = "LIVE")]
+    Live,
+    #[serde(rename = "SIMULATION")]
+    Simulation,
+}
+
+/// Parameters for [`PolyforgeClient::start_strategy`].
+///
+/// Platform contract (POST `/api/v1/strategies/{id}/start`):
+/// `{ "paperMode": bool, "deploymentMode"?: "LIVE"|"SIMULATION" }`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartStrategyParams {
+    pub paper_mode: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_mode: Option<DeploymentMode>,
+}
+
+impl StartStrategyParams {
+    /// Convenience constructor: paper trading with no explicit deployment mode.
+    pub fn paper() -> Self {
+        Self { paper_mode: true, deployment_mode: None }
+    }
+
+    /// Convenience constructor: live trading with no explicit deployment mode.
+    pub fn live() -> Self {
+        Self { paper_mode: false, deployment_mode: None }
+    }
 }
 
 /// A trading strategy.


### PR DESCRIPTION
## Summary

- Fixes the silent live-order bug: `start_strategy` was sending `{ mode: "paper" }` which the platform ignores, defaulting `paperMode` to `false` and executing real orders.
- Adds `DeploymentMode` enum (`LIVE` / `SIMULATION`) and `StartStrategyParams` struct with `paper_mode: bool` + optional `deployment_mode`.
- Provides `StartStrategyParams::paper()` / `::live()` convenience constructors.
- `TradingMode` is kept intact (still used to deserialize `Strategy.mode` from responses).
- Adds 3 contract compliance regression tests pinned to issue #145.

## Platform contract
POST /api/v1/strategies/{id}/start expects: { "paperMode": bool, "deploymentMode"?: "LIVE" | "SIMULATION" }

## Migration
Before: client.start_strategy(id, TradingMode::Paper).await?;
After:  client.start_strategy(id, StartStrategyParams::paper()).await?;

## Test plan
- cargo test — 192 passed, 0 failed
- test_start_strategy_paper_payload — verifies paperMode: true, no mode field
- test_start_strategy_live_payload — verifies paperMode: false, no mode field
- test_start_strategy_with_deployment_mode — verifies LIVE/SIMULATION serialization

Closes #145 / POLA-480