### PR TITLE
fix(deps): bump rustls-webpki 0.103.12 → 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Bumps `rustls-webpki` from `0.103.12` to `0.103.13` (transitive via `reqwest → rustls`)
- Resolves **RUSTSEC-2026-0104** / **GHSA-82j2-j2ch-gfr8**: reachable panic in CRL parsing via crafted `IssuingDistributionPoint` extension with empty `BIT STRING` in `onlySomeReasons`
- Panic is reachable before CRL signature verification — any attacker able to supply a CRL can trigger it

## Verification

- `cargo audit`: 0 vulnerabilities (was 1)
- `cargo test`: 218 unit + 4 doc-tests pass
- `cargo clippy -- -D warnings`: clean

## Test plan

- [x] `cargo audit` shows clean output
- [x] All 222 tests pass (218 unit + 4 doc)
- [x] `cargo clippy` passes with `-D warnings`
- [ ] CI checks pass

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)