### PR TITLE
fix(compat): rewrite CopyConfig to wallet-based platform model (POLA-783)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3307,30 +3307,39 @@ mod tests {
 
     #[test]
     fn test_copy_config_deserializes_platform_fields() {
-        // #146: CopyConfig must use strategy-based model (sourceStrategyId, allocationPercent)
+        // #168: CopyConfig must use wallet-based model (targetWallet, mode, sizeValue, etc.)
         let json = r#"{
             "id": "cc1",
-            "sourceStrategyId": "strat-uuid-abc",
-            "name": "My Copy",
-            "allocationPercent": 50,
-            "initialBalance": "1000",
-            "enabled": true
+            "targetWallet": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "mode": "PERCENTAGE",
+            "sizeValue": "100.5",
+            "maxExposure": "500",
+            "maxDailyLoss": "50",
+            "priceOffset": "0.01",
+            "status": "ACTIVE",
+            "createdAt": "2026-01-01T00:00:00Z"
         }"#;
         let config: CopyConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.source_strategy_id, Some("strat-uuid-abc".to_string()));
-        assert_eq!(config.name, Some("My Copy".to_string()));
-        assert_eq!(config.allocation_percent, Some(50));
-        assert_eq!(config.initial_balance, Some("1000".to_string()));
-        assert_eq!(config.enabled, Some(true));
+        assert_eq!(
+            config.target_wallet.as_deref(),
+            Some("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+        );
+        assert_eq!(config.mode, Some(CopyMode::Percentage));
+        assert_eq!(config.size_value.as_deref(), Some("100.5"));
+        assert_eq!(config.max_exposure.as_deref(), Some("500"));
+        assert_eq!(config.max_daily_loss.as_deref(), Some("50"));
+        assert_eq!(config.price_offset.as_deref(), Some("0.01"));
+        assert_eq!(config.status.as_deref(), Some("ACTIVE"));
+        assert_eq!(config.created_at.as_deref(), Some("2026-01-01T00:00:00Z"));
     }
 
     #[test]
-    fn test_copy_config_wallet_fields_go_to_extra() {
-        // #146: Old wallet-based fields must NOT map to named fields
-        let json = r#"{"id":"cc1","targetWallet":"0xabc","mode":"PERCENTAGE"}"#;
+    fn test_copy_config_strategy_fields_go_to_extra() {
+        // #168: Old strategy-based fields must NOT map to named fields
+        let json = r#"{"id":"cc1","sourceStrategyId":"strat-uuid","allocationPercent":50}"#;
         let config: CopyConfig = serde_json::from_str(json).unwrap();
-        assert!(config.source_strategy_id.is_none());
-        assert!(config.allocation_percent.is_none());
+        assert!(config.target_wallet.is_none());
+        assert!(config.mode.is_none());
     }
 
     #[test]
@@ -4318,31 +4327,38 @@ mod tests {
     // ── Copy trading CRUD (#51) ───────────────────────────────────────────────
 
     #[test]
-    fn test_create_copy_config_params_serializes_strategy_fields() {
-        // #146: CreateCopyConfigParams must send sourceStrategyId, not targetWallet
+    fn test_create_copy_config_params_serializes_wallet_fields() {
+        // #168: CreateCopyConfigParams must send targetWallet, not sourceStrategyId
         let params = CreateCopyConfigParams {
-            source_strategy_id: "strat-uuid-123".to_string(),
-            name: Some("My Copy".to_string()),
-            allocation_percent: Some(50),
+            target_wallet: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+            mode: Some(CopyMode::Percentage),
+            size_value: Some("100".to_string()),
             ..Default::default()
         };
         let body = serde_json::to_value(&params).unwrap();
-        assert_eq!(body["sourceStrategyId"], "strat-uuid-123");
-        assert_eq!(body["name"], "My Copy");
-        assert_eq!(body["allocationPercent"], 50);
-        assert!(body.get("targetWallet").is_none());
+        assert_eq!(
+            body["targetWallet"],
+            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        );
+        assert_eq!(body["mode"], "PERCENTAGE");
+        assert_eq!(body["sizeValue"], "100");
+        assert!(body.get("sourceStrategyId").is_none());
+        assert!(body.get("allocationPercent").is_none());
     }
 
     #[test]
     fn test_update_copy_config_params_skips_none_fields() {
         let params = UpdateCopyConfigParams {
-            allocation_percent: Some(75),
+            mode: Some(CopyMode::Fixed),
+            size_value: Some("200".to_string()),
             ..Default::default()
         };
         let body = serde_json::to_value(&params).unwrap();
-        assert_eq!(body["allocationPercent"], 75);
+        assert_eq!(body["mode"], "FIXED");
+        assert_eq!(body["sizeValue"], "200");
         // None fields should be absent due to skip_serializing_if
-        assert!(body.get("name").is_none());
+        assert!(body.get("maxExposure").is_none());
+        assert!(body.get("maxDailyLoss").is_none());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -703,23 +703,41 @@ pub struct Alert {
     pub extra: serde_json::Value,
 }
 
-/// A copy-trading configuration (strategy-based).
+/// Copy mode matching the platform's `CopyModeDto`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CopyMode {
+    Percentage,
+    Fixed,
+    Mirror,
+}
+
+/// A copy-trading configuration (wallet-based platform model).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CopyConfig {
     pub id: String,
-    /// The strategy being copied.
     #[serde(default)]
-    pub source_strategy_id: Option<String>,
+    pub target_wallet: Option<String>,
     #[serde(default)]
-    pub name: Option<String>,
-    /// Allocation as a percentage (0–100).
+    pub mode: Option<CopyMode>,
     #[serde(default)]
-    pub allocation_percent: Option<u8>,
+    pub size_value: Option<String>,
     #[serde(default)]
-    pub initial_balance: Option<String>,
+    pub max_exposure: Option<String>,
     #[serde(default)]
-    pub enabled: Option<bool>,
+    pub max_daily_loss: Option<String>,
+    #[serde(default)]
+    pub price_offset: Option<String>,
+    /// Platform status: ACTIVE | PAUSED | STOPPED | ERROR
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+    #[serde(default)]
+    pub stopped_at: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -1376,27 +1394,37 @@ pub struct GetPortfolioPnlParams {
 // Copy trading CRUD params
 // ---------------------------------------------------------------------------
 
-/// Parameters for creating a copy trading configuration (platform contract).
+/// Parameters for creating a copy trading configuration (wallet-based platform contract).
 #[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateCopyConfigParams {
-    pub source_strategy_id: String,
+    pub target_wallet: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub mode: Option<CopyMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub initial_balance: Option<String>,
+    pub size_value: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allocation_percent: Option<u8>,
+    pub max_exposure: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_daily_loss: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price_offset: Option<String>,
 }
 
-/// Parameters for updating a copy trading configuration.
+/// Parameters for updating a copy trading configuration (wallet-based platform contract).
 #[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateCopyConfigParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub mode: Option<CopyMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allocation_percent: Option<u8>,
+    pub size_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_exposure: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_daily_loss: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price_offset: Option<String>,
 }
 
 /// Parameters for fetching trades of a copy config.


### PR DESCRIPTION
## Summary

- Replaced `CreateCopyConfigParams` strategy-based fields (`sourceStrategyId`, `name`, `allocationPercent`, `initialBalance`) with the platform's actual wallet-based contract: `targetWallet`, `mode`, `sizeValue`, `maxExposure`, `maxDailyLoss`, `priceOffset`
- Added `CopyMode` enum (`PERCENTAGE | FIXED | MIRROR`) with `SCREAMING_SNAKE_CASE` serde mapping to match `CopyModeDto` in the platform
- Rewrote `CopyConfig` response struct to match the platform Prisma model: `targetWallet`, `mode`, `sizeValue`, `maxExposure`, `maxDailyLoss`, `priceOffset`, `status`, `createdAt`, `updatedAt`, `stoppedAt`
- Updated `UpdateCopyConfigParams` to match `UpdateCopyDto` (mode, sizeValue, maxExposure, maxDailyLoss, priceOffset — no wallet field since wallet is immutable post-create)
- Updated all affected tests to assert correct wallet-based serialization/deserialization

## Root cause

The platform enforces `forbidNonWhitelisted` on `POST /api/v1/copy`, meaning any unknown field causes a 400. The old `source_strategy_id` would have caused every `create_copy_config` call to fail at runtime. The TypeScript and Python SDKs both used the correct wallet-based model; Rust was the outlier.

## Test plan

- [x] `cargo test` — 218 passed, 0 failed
- [x] `test_copy_config_deserializes_platform_fields` — asserts `targetWallet`, `mode`, `sizeValue`, `status`, `createdAt` map correctly
- [x] `test_copy_config_strategy_fields_go_to_extra` — asserts old strategy fields fall through to `extra` (no named field conflict)
- [x] `test_create_copy_config_params_serializes_wallet_fields` — asserts `targetWallet` and `mode` serialize, `sourceStrategyId`/`allocationPercent` absent
- [x] `test_update_copy_config_params_skips_none_fields` — asserts None fields are skipped

Closes #168 | Paperclip: POLA-783

🤖 Generated with [Claude Code](https://claude.com/claude-code)