### PR TITLE
fix: send {mode} instead of {paperMode} in start_strategy (closes #173)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3021,47 +3021,18 @@ mod tests {
 
     #[test]
     fn test_start_strategy_paper_payload() {
-        // #145: start_strategy must send { paperMode: true } not { mode: "paper" }
+        // #173: start_strategy must send { mode: "paper" } to match platform contract
         let body = serde_json::to_value(StartStrategyParams::paper()).unwrap();
-        assert_eq!(body["paperMode"], serde_json::Value::Bool(true));
-        assert!(body.get("mode").is_none(), "must not send legacy `mode` field");
-        assert!(
-            body.get("deploymentMode").is_none(),
-            "deploymentMode must be absent when None"
-        );
+        assert_eq!(body["mode"], serde_json::Value::String("paper".to_string()));
+        assert!(body.get("paperMode").is_none(), "must not send obsolete `paperMode` field");
     }
 
     #[test]
     fn test_start_strategy_live_payload() {
-        // #145: start_strategy must send { paperMode: false } not { mode: "live" }
+        // #173: start_strategy must send { mode: "live" } to match platform contract
         let body = serde_json::to_value(StartStrategyParams::live()).unwrap();
-        assert_eq!(body["paperMode"], serde_json::Value::Bool(false));
-        assert!(body.get("mode").is_none(), "must not send legacy `mode` field");
-    }
-
-    #[test]
-    fn test_start_strategy_with_deployment_mode() {
-        // #145: DeploymentMode serializes as uppercase "LIVE" / "SIMULATION"
-        let params = StartStrategyParams {
-            paper_mode: false,
-            deployment_mode: Some(DeploymentMode::Live),
-        };
-        let body = serde_json::to_value(&params).unwrap();
-        assert_eq!(body["paperMode"], serde_json::Value::Bool(false));
-        assert_eq!(
-            body["deploymentMode"],
-            serde_json::Value::String("LIVE".to_string())
-        );
-
-        let sim = StartStrategyParams {
-            paper_mode: true,
-            deployment_mode: Some(DeploymentMode::Simulation),
-        };
-        let body2 = serde_json::to_value(&sim).unwrap();
-        assert_eq!(
-            body2["deploymentMode"],
-            serde_json::Value::String("SIMULATION".to_string())
-        );
+        assert_eq!(body["mode"], serde_json::Value::String("live".to_string()));
+        assert!(body.get("paperMode").is_none(), "must not send obsolete `paperMode` field");
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -183,38 +183,22 @@ pub enum TradingMode {
     Paper,
 }
 
-/// Deployment mode sent when starting a strategy.
-///
-/// Platform contract: `"LIVE"` or `"SIMULATION"`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum DeploymentMode {
-    #[serde(rename = "LIVE")]
-    Live,
-    #[serde(rename = "SIMULATION")]
-    Simulation,
-}
-
 /// Parameters for [`PolyforgeClient::start_strategy`].
 ///
 /// Platform contract (POST `/api/v1/strategies/{id}/start`):
-/// `{ "paperMode": bool, "deploymentMode"?: "LIVE"|"SIMULATION" }`.
+/// `{ "mode": "live"|"paper" }`.
 #[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct StartStrategyParams {
-    pub paper_mode: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deployment_mode: Option<DeploymentMode>,
+    pub mode: TradingMode,
 }
 
 impl StartStrategyParams {
-    /// Convenience constructor: paper trading with no explicit deployment mode.
     pub fn paper() -> Self {
-        Self { paper_mode: true, deployment_mode: None }
+        Self { mode: TradingMode::Paper }
     }
 
-    /// Convenience constructor: live trading with no explicit deployment mode.
     pub fn live() -> Self {
-        Self { paper_mode: false, deployment_mode: None }
+        Self { mode: TradingMode::Live }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaced `StartStrategyParams { paper_mode: bool, deployment_mode: Option<DeploymentMode> }` with `StartStrategyParams { mode: TradingMode }`
- Removed `DeploymentMode` enum (no longer in platform contract)
- Platform contract now expects `{mode: "live"|"paper"}` — the old `{paperMode}` payload caused 100% failure rate
- Updated tests to verify `mode` field serialization

## Test plan

- [x] All 241 unit tests + 4 doc-tests pass
- [x] `test_start_strategy_paper_payload` verifies `{"mode":"paper"}` and no `paperMode`
- [x] `test_start_strategy_live_payload` verifies `{"mode":"live"}` and no `paperMode`

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)