### PR TITLE
fix: flatten PaginatedResponse to match platform shape

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3443,15 +3443,15 @@ mod tests {
 
     #[test]
     fn test_paginated_response_deserializes_strategies() {
-        // #76 / #142: PaginatedResponse uses nested pagination object matching platform contract
         let json = r#"{
             "data": [{"id":"s1","name":"Alpha"},{"id":"s2","name":"Beta"}],
-            "pagination": {"page": 1, "limit": 10, "total": 2, "totalPages": 1}
+            "total": 2, "page": 1, "limit": 10, "totalPages": 1, "hasNext": true
         }"#;
         let resp: PaginatedResponse<Strategy> = serde_json::from_str(json).unwrap();
         assert_eq!(resp.data.len(), 2);
-        assert_eq!(resp.pagination.total, 2);
-        assert_eq!(resp.pagination.page, 1);
+        assert_eq!(resp.total, 2);
+        assert_eq!(resp.page, 1);
+        assert_eq!(resp.has_next, true);
         assert_eq!(resp.data[0].id, "s1");
     }
 
@@ -4503,12 +4503,12 @@ mod tests {
     fn test_paginated_conditional_orders_deserializes() {
         let json = r#"{
             "data": [{"id": "co-1"}, {"id": "co-2"}],
-            "pagination": {"page": 1, "limit": 10, "total": 2, "totalPages": 1}
+            "total": 2, "page": 1, "limit": 10, "totalPages": 1, "hasNext": false
         }"#;
         let resp: PaginatedResponse<ConditionalOrder> = serde_json::from_str(json).unwrap();
         assert_eq!(resp.data.len(), 2);
         assert_eq!(resp.data[0].id, "co-1");
-        assert_eq!(resp.pagination.total, 2);
+        assert_eq!(resp.total, 2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! async fn main() -> polyforge::Result<()> {
 //!     let client = PolyforgeClient::new("your-api-key")?;
 //!     let markets = client.list_markets(&Default::default()).await?;
-//!     println!("Found {} markets", markets.pagination.total);
+//!     println!("Found {} markets", markets.total);
 //!     Ok(())
 //! }
 //! ```

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,21 +4,16 @@ use serde::{Deserialize, Serialize};
 // Paginated wrapper
 // ---------------------------------------------------------------------------
 
-/// Pagination metadata nested under the `pagination` key.
+/// A paginated API response with flat pagination fields matching the platform.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Pagination {
-    pub page: u64,
-    pub limit: u64,
-    pub total: u64,
-    pub total_pages: u64,
-}
-
-/// A paginated API response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaginatedResponse<T> {
     pub data: Vec<T>,
-    pub pagination: Pagination,
+    pub total: u64,
+    pub page: u64,
+    pub limit: u64,
+    pub total_pages: u64,
+    pub has_next: bool,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause:** Platform returns flat pagination fields (`page`, `limit`, `total`, `totalPages`, `hasNext`) at the response root, but SDK PR #142 incorrectly used a nested `Pagination` struct
- Replace `Pagination` struct with flat fields on `PaginatedResponse` using `serde(rename_all = "camelCase")`
- Add `has_next: bool` field (was missing from the nested struct)
- Update doc example and all test assertions

Closes #178

## Test plan

- [x] All 259 unit tests + 4 doc-tests pass
- [x] Updated deserialization tests verify flat JSON shape
- [x] No stale `.pagination.` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)