### PR TITLE
docs: correct PolyforgeClient default endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ async fn main() -> polyforge::Result<()> {
 
 | Method | Description |
 |--------|-------------|
-| `PolyforgeClient::new(api_key)` | Connect to `https://localhost:3002` |
-| `PolyforgeClient::with_url(api_key, url)` | Connect to a custom URL |
+| `PolyforgeClient::new(api_key)` | Use `POLYFORGE_API_URL` when set; otherwise connect to `https://api.polyforge.app` |
+| `PolyforgeClient::with_url(api_key, url)` | Connect to a custom URL, including local/dev endpoints such as `http://localhost:3002` |
 
 ### Markets
 


### PR DESCRIPTION
## Summary
- Update the README client construction table for `PolyforgeClient::new(api_key)` to document `POLYFORGE_API_URL` first and `https://api.polyforge.app` as the fallback.
- Keep `PolyforgeClient::with_url(api_key, url)` as the documented custom/local dev override path.

## Verification
- `git diff --check -- README.md`
- `rg -n "PolyforgeClient::new\\(api_key\\).*POLYFORGE_API_URL.*https://api\\.polyforge\\.app|PolyforgeClient::with_url\\(api_key, url\\).*http://localhost:3002" README.md`
- GitNexus `detect_changes(scope: all)` after the README edit: low risk, 1 changed file, 0 affected processes.

Closes #181
