### PR TITLE
fix(types): mirror platform UpdateNotificationsDto in NotificationSettings (closes #184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 
   New types: `UserPerformancePoint`, `UserStrategySummary`, `UserActivityEntry`, `UserProfileBadge`, `FollowedUser`, plus an internal `UserDataEnvelope<T>` to unwrap the `{ "data": [...] }` envelope.
 
+### Fixed
+- **NotificationSettings / UpdateNotificationSettingsParams** — rewrite both structs to mirror the platform's `UpdateNotificationsDto`. Removes fictional fields (`pushEnabled`, `orderFills`, `strategyErrors`, `whaleAlerts`, `marketResolutions`, `dailySummary`) that the platform rejected with 400 under `forbidNonWhitelisted: true`, and adds the real DTO fields (`telegramEnabled`, `discordEnabled`, `onOrderFilled`, `onStrategyError`, `onBacktestComplete`, `onDailyLossLimit`, `onMarketResolved`, `onSomeoneForked`, `onSomeoneFollowed`, `onSomeoneLiked`, `onSomeoneCommented`). The `extra` flatten bucket is preserved on the read struct so server-only fields (`userId`, `updatedAt`, `eventPrefs`, `emailDigest`, `notificationFreq`, `minFillNotifyUsdc`, `onTicketReply`) round-trip. Added a wire-format key-set test. (closes #184)
+
 ## [1.7.6] — 2026-04-25
 
 ### Fixed

--- a/src/client.rs
+++ b/src/client.rs
@@ -5843,27 +5843,128 @@ mod tests {
 
     #[test]
     fn test_notification_settings_deserializes() {
-        let json = r#"{"emailEnabled":true,"pushEnabled":false,"orderFills":true,"strategyErrors":true,"whaleAlerts":false,"marketResolutions":true,"dailySummary":false}"#;
+        // Real shape returned by GET /api/v1/settings/notifications, mirroring
+        // the Prisma `NotificationPreference` row + `UpdateNotificationsDto`
+        // contract. Includes server-only / forward-compat fields that must
+        // round-trip through the `extra` flatten bucket.
+        let json = r#"{
+            "userId": "user_abc123",
+            "emailEnabled": true,
+            "telegramEnabled": false,
+            "discordEnabled": false,
+            "onOrderFilled": true,
+            "onStrategyError": true,
+            "onBacktestComplete": true,
+            "onDailyLossLimit": true,
+            "onMarketResolved": true,
+            "onSomeoneForked": false,
+            "onSomeoneFollowed": false,
+            "onSomeoneLiked": false,
+            "onSomeoneCommented": false,
+            "onTicketReply": true,
+            "minFillNotifyUsdc": "0.00",
+            "notificationFreq": "IMMEDIATE",
+            "emailDigest": "DAILY",
+            "updatedAt": "2026-04-01T12:00:00.000Z"
+        }"#;
         let ns: NotificationSettings = serde_json::from_str(json).unwrap();
         assert_eq!(ns.email_enabled, Some(true));
-        assert_eq!(ns.push_enabled, Some(false));
-        assert_eq!(ns.order_fills, Some(true));
+        assert_eq!(ns.telegram_enabled, Some(false));
+        assert_eq!(ns.discord_enabled, Some(false));
+        assert_eq!(ns.on_order_filled, Some(true));
+        assert_eq!(ns.on_strategy_error, Some(true));
+        assert_eq!(ns.on_backtest_complete, Some(true));
+        assert_eq!(ns.on_daily_loss_limit, Some(true));
+        assert_eq!(ns.on_market_resolved, Some(true));
+        assert_eq!(ns.on_someone_forked, Some(false));
+        assert_eq!(ns.on_someone_followed, Some(false));
+        assert_eq!(ns.on_someone_liked, Some(false));
+        assert_eq!(ns.on_someone_commented, Some(false));
+        // Server-only / forward-compat fields must be preserved in `extra`.
+        assert_eq!(ns.extra["userId"], "user_abc123");
+        assert_eq!(ns.extra["onTicketReply"], true);
+        assert_eq!(ns.extra["emailDigest"], "DAILY");
+        assert_eq!(ns.extra["notificationFreq"], "IMMEDIATE");
     }
 
     #[test]
     fn test_update_notification_settings_omits_none() {
         let p = UpdateNotificationSettingsParams {
             email_enabled: Some(true),
-            push_enabled: None,
-            order_fills: None,
-            strategy_errors: None,
-            whale_alerts: None,
-            market_resolutions: None,
-            daily_summary: None,
+            telegram_enabled: None,
+            discord_enabled: None,
+            on_order_filled: None,
+            on_strategy_error: None,
+            on_backtest_complete: None,
+            on_daily_loss_limit: None,
+            on_market_resolved: None,
+            on_someone_forked: None,
+            on_someone_followed: None,
+            on_someone_liked: None,
+            on_someone_commented: None,
         };
         let v = serde_json::to_value(&p).unwrap();
         assert_eq!(v["emailEnabled"], true);
-        assert!(v.get("pushEnabled").is_none());
+        assert!(v.get("telegramEnabled").is_none());
+        assert!(v.get("discordEnabled").is_none());
+        assert!(v.get("onOrderFilled").is_none());
+    }
+
+    /// Wire-format keys must exactly match the platform `UpdateNotificationsDto`.
+    /// `forbidNonWhitelisted: true` on the platform rejects any field the DTO
+    /// does not declare, so this guards against future drift.
+    #[test]
+    fn test_update_notification_settings_camel_case_keys() {
+        let p = UpdateNotificationSettingsParams {
+            email_enabled: Some(true),
+            telegram_enabled: Some(false),
+            discord_enabled: Some(false),
+            on_order_filled: Some(true),
+            on_strategy_error: Some(true),
+            on_backtest_complete: Some(true),
+            on_daily_loss_limit: Some(true),
+            on_market_resolved: Some(true),
+            on_someone_forked: Some(false),
+            on_someone_followed: Some(false),
+            on_someone_liked: Some(false),
+            on_someone_commented: Some(false),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        let obj = v.as_object().expect("serialized as object");
+
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort();
+        let mut expected = vec![
+            "emailEnabled",
+            "telegramEnabled",
+            "discordEnabled",
+            "onOrderFilled",
+            "onStrategyError",
+            "onBacktestComplete",
+            "onDailyLossLimit",
+            "onMarketResolved",
+            "onSomeoneForked",
+            "onSomeoneFollowed",
+            "onSomeoneLiked",
+            "onSomeoneCommented",
+        ];
+        expected.sort();
+        assert_eq!(keys, expected);
+
+        // Stale / fictional fields from the previous schema must not leak.
+        for stale in &[
+            "pushEnabled",
+            "orderFills",
+            "strategyErrors",
+            "whaleAlerts",
+            "marketResolutions",
+            "dailySummary",
+        ] {
+            assert!(
+                obj.get(*stale).is_none(),
+                "stale field `{stale}` must not appear in serialized output",
+            );
+        }
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2237,44 +2237,83 @@ pub struct UpdateSettingsProfileParams {
     pub twitter_handle: Option<String>,
 }
 
+/// Notification settings as returned by `GET /api/v1/settings/notifications`.
+///
+/// Field names mirror the platform's `UpdateNotificationsDto` plus the
+/// underlying `NotificationPreference` Prisma row (camelCase on the wire).
+/// Unknown fields returned by the server (`userId`, `updatedAt`,
+/// `eventPrefs`, `emailDigest`, `notificationFreq`, `minFillNotifyUsdc`,
+/// `onTicketReply`, ...) are preserved in `extra` so that callers using a
+/// newer platform release do not lose data on round-trip.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct NotificationSettings {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email_enabled: Option<bool>,
-    #[serde(default)]
-    pub push_enabled: Option<bool>,
-    #[serde(default)]
-    pub order_fills: Option<bool>,
-    #[serde(default)]
-    pub strategy_errors: Option<bool>,
-    #[serde(default)]
-    pub whale_alerts: Option<bool>,
-    #[serde(default)]
-    pub market_resolutions: Option<bool>,
-    #[serde(default)]
-    pub daily_summary: Option<bool>,
-    #[serde(flatten)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub telegram_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discord_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_order_filled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_strategy_error: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_backtest_complete: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_daily_loss_limit: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_market_resolved: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_someone_forked: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_someone_followed: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_someone_liked: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_someone_commented: Option<bool>,
+    /// Forward-compat bucket for any additional fields the platform
+    /// returns (e.g. `userId`, `updatedAt`, `eventPrefs`, `emailDigest`,
+    /// `notificationFreq`, `minFillNotifyUsdc`, `onTicketReply`).
+    #[serde(default, flatten)]
     pub extra: serde_json::Value,
 }
 
+/// Parameters for `PATCH /api/v1/settings/notifications`.
+///
+/// Mirrors the platform's `UpdateNotificationsDto` exactly. The platform
+/// runs `ValidationPipe` with `whitelist: true, forbidNonWhitelisted: true`,
+/// so this struct intentionally only contains fields that the DTO accepts
+/// — sending anything else returns 400. Use `None` for any field you do
+/// not want to touch; `serde(skip_serializing_if = "Option::is_none")`
+/// keeps the request body to a true partial update.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateNotificationSettingsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email_enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub push_enabled: Option<bool>,
+    pub telegram_enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub order_fills: Option<bool>,
+    pub discord_enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub strategy_errors: Option<bool>,
+    pub on_order_filled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub whale_alerts: Option<bool>,
+    pub on_strategy_error: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub market_resolutions: Option<bool>,
+    pub on_backtest_complete: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub daily_summary: Option<bool>,
+    pub on_daily_loss_limit: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_market_resolved: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_someone_forked: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_someone_followed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_someone_liked: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_someone_commented: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem

`NotificationSettings` and `UpdateNotificationSettingsParams` in `src/types.rs` did not match the platform's `UpdateNotificationsDto` (`services/api-service/src/settings/dto/update-notifications.dto.ts`).

The SDK serialized fields like `pushEnabled`, `orderFills`, `strategyErrors`, `whaleAlerts`, `marketResolutions`, `dailySummary` — none of which exist in the platform DTO. Because the platform's `ValidationPipe` runs with `whitelist: true, forbidNonWhitelisted: true`, every non-empty `update_notification_settings()` call that set any of those fields returned **400**.

On reads, `NotificationSettings` deserialization "succeeded" only because `#[serde(flatten)] extra` swallowed the unknown fields — so every typed field was always `None` and callers could not inspect any actual notification setting through the typed struct.

The full set of platform fields — channel toggles (`telegramEnabled`, `discordEnabled`) and event toggles (`onOrderFilled`, `onStrategyError`, `onBacktestComplete`, `onDailyLossLimit`, `onMarketResolved`, `onSomeoneForked`, `onSomeoneFollowed`, `onSomeoneLiked`, `onSomeoneCommented`) — was therefore unreachable from sdk-rust.

## What changed

`src/types.rs`:
- `NotificationSettings` (read shape) — replace fictional fields with the 12 real DTO fields; keep `extra: serde_json::Value` flatten bucket so server-only fields (`userId`, `updatedAt`, `eventPrefs`, `emailDigest`, `notificationFreq`, `minFillNotifyUsdc`, `onTicketReply`) round-trip without loss.
- `UpdateNotificationSettingsParams` (write shape) — same 12 fields, all `Option<bool>` with `#[serde(skip_serializing_if = "Option::is_none")]` for true partial updates. Kept as a distinct struct (not a type alias) so callers cannot accidentally try to write read-only server fields.

`src/client.rs`:
- `test_notification_settings_deserializes`: rewritten with a realistic platform payload (12 typed fields + 4 server-only fields). Asserts both the typed fields and that `extra` preserves `userId` / `onTicketReply` / `emailDigest` / `notificationFreq`.
- `test_update_notification_settings_omits_none`: updated for the new shape.
- `test_update_notification_settings_camel_case_keys` (new): pins the wire key set to the exact 12 DTO fields; explicitly asserts the 6 stale fictional fields never appear in serialized output. Guards against future drift since `forbidNonWhitelisted: true` rejects any unknown key.

`CHANGELOG.md`: entry under `[Unreleased]`.

## Verification

- `cargo build` — clean
- `cargo test --lib` — **260 passed, 0 failed** (test count went up by 1 due to the new key-set assertion)
- `cargo clippy --lib --all-targets` — only the pre-existing `bool_assert_comparison` warning at `src/client.rs:3454` (unrelated, present on `master`)

## Breaking change

Yes — public API. Field names changed on both `NotificationSettings` and `UpdateNotificationSettingsParams`. The previous fields were fictional and never worked, so no real caller can be affected on the write path; on the read path callers were always seeing `None` so any real value extraction required hand-parsing through `extra`.

Recommend a minor-or-major version bump on next release.

closes #184