### PR TITLE
fix(arbitrage): align Rust arb validation with SDK spec (POLA-1873)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - **Cross-venue arb execution / positions / risk endpoints (POLA-1852)** — 7 trading-impact-bearing methods that complete the `/api/v1/arbitrage/*` surface and bring the Rust SDK to parity with the Python SDK (POLA-1851):
-  - `execute_arbitrage(&ExecuteArbitrageParams)` → `POST /api/v1/arbitrage/execute`. Validates `match_id` length 1..=255, integer `size` ∈ `1..=10000` USDC, and `max_slippage_pct` ∈ `0..=5` client-side before the order hits the wire (mirrors `ExecuteArbDto` `class-validator` bounds).
+  - `execute_arbitrage(&ExecuteArbitrageParams)` → `POST /api/v1/arbitrage/execute`. Validates UUID `match_id`, integer `size` ∈ `1..=10000` USDC, and `max_slippage_pct` ∈ `0..=5` client-side before the order hits the wire (mirrors `ExecuteArbDto` `class-validator` bounds).
   - `list_arbitrage_positions(status, limit, offset)` → `GET /api/v1/arbitrage/positions`. Uses typed `ArbPositionStatus` and validates `limit` ∈ `1..=100`.
   - `get_arbitrage_position(id)` → `GET /api/v1/arbitrage/positions/{id}`.
   - `close_arbitrage_position(id)` → `POST /api/v1/arbitrage/positions/{id}/close`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@
 
 ### Added
 - **Cross-venue arb execution / positions / risk endpoints (POLA-1852)** — 7 trading-impact-bearing methods that complete the `/api/v1/arbitrage/*` surface and bring the Rust SDK to parity with the Python SDK (POLA-1851):
-  - `execute_arbitrage(&ExecuteArbitrageParams)` → `POST /api/v1/arbitrage/execute`. Validates `size` ∈ `1..=10000` USDC and `max_slippage_pct` ∈ `0..=5` client-side before the order hits the wire (mirrors `ExecuteArbDto` `class-validator` bounds).
-  - `list_arbitrage_positions(status, limit, offset)` → `GET /api/v1/arbitrage/positions`.
+  - `execute_arbitrage(&ExecuteArbitrageParams)` → `POST /api/v1/arbitrage/execute`. Validates `match_id` length 1..=255, integer `size` ∈ `1..=10000` USDC, and `max_slippage_pct` ∈ `0..=5` client-side before the order hits the wire (mirrors `ExecuteArbDto` `class-validator` bounds).
+  - `list_arbitrage_positions(status, limit, offset)` → `GET /api/v1/arbitrage/positions`. Uses typed `ArbPositionStatus` and validates `limit` ∈ `1..=100`.
   - `get_arbitrage_position(id)` → `GET /api/v1/arbitrage/positions/{id}`.
   - `close_arbitrage_position(id)` → `POST /api/v1/arbitrage/positions/{id}/close`.
   - `get_arbitrage_risk_dashboard()` → `GET /api/v1/arbitrage/risk/dashboard`.
   - `get_arbitrage_settlement_risks()` → `GET /api/v1/arbitrage/risk/settlement`.
   - `refresh_arbitrage_pnl()` → `POST /api/v1/arbitrage/risk/refresh-pnl`.
-- New types: `ExecuteArbitrageParams`, `ArbExecutionLeg`, `ArbExecutionResult`, `ArbPosition`, `ArbPositionsResponse`, `ArbCloseResponse`, `ArbNetExposure`, `ArbRiskDashboard`, `ArbSettlementRisk`, `ArbPnlRefreshResult`. Decimal columns (`buy_price`, `sell_price`, P&L, spread) are typed as `Option<String>` to preserve full precision from the backend Prisma `Decimal` serialization, matching the Python SDK shape.
+- New types: `ExecuteArbitrageParams`, `ArbPositionStatus`, `ArbExecutionLeg`, `ArbExecutionResult`, `ArbPosition`, `ArbPositionsResponse`, `ArbCloseResponse`, `ArbNetExposure`, `ArbRiskDashboard`, `ArbSettlementRisk`, `ArbPnlRefreshResult`. Decimal columns (`buy_price`, `sell_price`, P&L, spread) are typed as `Option<String>` to preserve full precision from the backend Prisma `Decimal` serialization, matching the Python SDK shape.
+
+### ⚠️ Trading impact (severity: HIGH)
+- `execute_arbitrage()` and `close_arbitrage_position()` can place real offsetting orders. The SDK now fails fast on malformed `match_id`, fractional or out-of-range `size`, invalid slippage, invalid position status filters, and oversized page limits before requests reach the trading API.
 
 ## [1.7.6] — 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ async fn main() -> polyforge::Result<()> {
 |--------|-------------|
 | `list_arbitrage_opportunities(min_spread)` | List cross-venue Polymarket/Kalshi opportunities |
 | `get_arbitrage_comparison(match_id)` | Compare prices for a matched cross-venue market |
-| `execute_arbitrage(params)` | Execute a real cross-venue arbitrage trade; validates `match_id` length, integer `size` 1..=10000, and optional slippage 0..=5 |
+| `execute_arbitrage(params)` | Execute a real cross-venue arbitrage trade; validates UUID `match_id`, integer `size` 1..=10000, and optional slippage 0..=5 |
 | `list_arbitrage_positions(status, limit, offset)` | List arbitrage positions with typed `ArbPositionStatus` and `limit` 1..=100 |
 | `get_arbitrage_position(position_id)` | Fetch one arbitrage position |
 | `close_arbitrage_position(position_id)` | Close an open arbitrage position with real reverse orders |

--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ async fn main() -> polyforge::Result<()> {
 | `place_order(params)` | Place a direct buy/sell order |
 | `cancel_order(order_id)` | Cancel a pending or live order |
 
+### Arbitrage
+
+| Method | Description |
+|--------|-------------|
+| `list_arbitrage_opportunities(min_spread)` | List cross-venue Polymarket/Kalshi opportunities |
+| `get_arbitrage_comparison(match_id)` | Compare prices for a matched cross-venue market |
+| `execute_arbitrage(params)` | Execute a real cross-venue arbitrage trade; validates `match_id` length, integer `size` 1..=10000, and optional slippage 0..=5 |
+| `list_arbitrage_positions(status, limit, offset)` | List arbitrage positions with typed `ArbPositionStatus` and `limit` 1..=100 |
+| `get_arbitrage_position(position_id)` | Fetch one arbitrage position |
+| `close_arbitrage_position(position_id)` | Close an open arbitrage position with real reverse orders |
+| `get_arbitrage_risk_dashboard()` | Get aggregate arbitrage exposure and P&L |
+| `get_arbitrage_settlement_risks()` | List settlement-date and resolution-criteria risks |
+| `refresh_arbitrage_pnl()` | Recompute unrealized arbitrage P&L |
+
 ### Social & Signals
 
 | Method | Description |

--- a/src/client.rs
+++ b/src/client.rs
@@ -156,9 +156,25 @@ fn validate_arb_size(value: f64) -> Result<()> {
             "size must be a finite number, got {value}"
         )));
     }
+    if value.fract() != 0.0 {
+        return Err(PolyforgeError::Validation(format!(
+            "size must be an integer USDC amount, got {value}"
+        )));
+    }
     if !(1.0..=10000.0).contains(&value) {
         return Err(PolyforgeError::Validation(format!(
             "size must be between 1 and 10000, got {value}"
+        )));
+    }
+    Ok(())
+}
+
+/// Reject match IDs outside the server-enforced 1..=255 character range.
+fn validate_arb_match_id(value: &str) -> Result<()> {
+    if value.is_empty() || value.len() > 255 {
+        return Err(PolyforgeError::Validation(format!(
+            "match_id must be between 1 and 255 characters, got {}",
+            value.len()
         )));
     }
     Ok(())
@@ -2400,7 +2416,8 @@ impl PolyforgeClient {
         &self,
         params: &ExecuteArbitrageParams,
     ) -> Result<ArbExecutionResult> {
-        validate_arb_size(params.size)?;
+        validate_arb_match_id(&params.match_id)?;
+        validate_arb_size(params.size as f64)?;
         if let Some(slip) = params.max_slippage_pct {
             validate_arb_slippage(slip)?;
         }
@@ -2414,15 +2431,20 @@ impl PolyforgeClient {
     /// `limit` defaults to 50 server-side and `offset` to 0.
     pub async fn list_arbitrage_positions(
         &self,
-        status: Option<&str>,
+        status: Option<ArbPositionStatus>,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> Result<ArbPositionsResponse> {
         let mut params = Vec::new();
         if let Some(s) = status {
-            params.push(format!("status={}", encode(s)));
+            params.push(format!("status={}", encode(s.as_str())));
         }
         if let Some(l) = limit {
+            if !(1..=100).contains(&l) {
+                return Err(PolyforgeError::Validation(format!(
+                    "limit must be between 1 and 100, got {l}"
+                )));
+            }
             params.push(format!("limit={}", l));
         }
         if let Some(o) = offset {
@@ -5508,7 +5530,7 @@ mod tests {
 
         let p = ExecuteArbitrageParams {
             match_id: "m-1".into(),
-            size: 100.0,
+            size: 100,
             max_slippage_pct: Some(0.5),
         };
         let v = serde_json::to_value(&p).unwrap();
@@ -5521,7 +5543,7 @@ mod tests {
     fn test_execute_arbitrage_params_omits_none_slippage() {
         let p = ExecuteArbitrageParams {
             match_id: "m-1".into(),
-            size: 50.0,
+            size: 50,
             max_slippage_pct: None,
         };
         let v = serde_json::to_value(&p).unwrap();
@@ -5533,10 +5555,19 @@ mod tests {
         assert!(validate_arb_size(1.0).is_ok());
         assert!(validate_arb_size(10000.0).is_ok());
         assert!(validate_arb_size(0.99).is_err());
+        assert!(validate_arb_size(100.5).is_err());
         assert!(validate_arb_size(10000.01).is_err());
         assert!(validate_arb_size(f64::NAN).is_err());
         assert!(validate_arb_size(f64::INFINITY).is_err());
         assert!(validate_arb_size(f64::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn test_validate_arb_match_id_bounds() {
+        assert!(validate_arb_match_id("m").is_ok());
+        assert!(validate_arb_match_id(&"x".repeat(255)).is_ok());
+        assert!(validate_arb_match_id("").is_err());
+        assert!(validate_arb_match_id(&"x".repeat(256)).is_err());
     }
 
     #[test]
@@ -5553,7 +5584,19 @@ mod tests {
         let client = PolyforgeClient::new("k").unwrap();
         let p = ExecuteArbitrageParams {
             match_id: "m-1".into(),
-            size: 0.5,
+            size: 0,
+            max_slippage_pct: None,
+        };
+        let err = client.execute_arbitrage(&p).await.unwrap_err();
+        assert!(matches!(err, PolyforgeError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn test_execute_arbitrage_rejects_bad_match_id() {
+        let client = PolyforgeClient::new("k").unwrap();
+        let p = ExecuteArbitrageParams {
+            match_id: "x".repeat(256),
+            size: 100,
             max_slippage_pct: None,
         };
         let err = client.execute_arbitrage(&p).await.unwrap_err();
@@ -5565,7 +5608,7 @@ mod tests {
         let client = PolyforgeClient::new("k").unwrap();
         let p = ExecuteArbitrageParams {
             match_id: "m-1".into(),
-            size: 100.0,
+            size: 100,
             max_slippage_pct: Some(7.5),
         };
         let err = client.execute_arbitrage(&p).await.unwrap_err();
@@ -5577,6 +5620,23 @@ mod tests {
         let client = PolyforgeClient::new("k").unwrap();
         let url = client.url("/api/v1/arbitrage/positions");
         assert!(url.ends_with("/api/v1/arbitrage/positions"));
+    }
+
+    #[tokio::test]
+    async fn test_list_arbitrage_positions_rejects_bad_limit() {
+        let client = PolyforgeClient::new("k").unwrap();
+        let err = client
+            .list_arbitrage_positions(None, Some(101), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PolyforgeError::Validation(_)));
+    }
+
+    #[test]
+    fn test_arb_position_status_deserializes_screaming_snake_case() {
+        let status: ArbPositionStatus = serde_json::from_str("\"PENDING\"").unwrap();
+        assert_eq!(status, ArbPositionStatus::Pending);
+        assert!(serde_json::from_str::<ArbPositionStatus>("\"EXPIRED\"").is_err());
     }
 
     #[test]
@@ -5631,7 +5691,7 @@ mod tests {
         let r: ArbExecutionResult = serde_json::from_str(json).unwrap();
         assert_eq!(r.arb_position_id.as_deref(), Some("ap-1"));
         assert_eq!(r.entry_spread_pct, Some(0.07));
-        assert_eq!(r.status.as_deref(), Some("PENDING"));
+        assert_eq!(r.status, Some(ArbPositionStatus::Pending));
         let buy = r.buy_leg.as_ref().unwrap();
         assert_eq!(buy.venue.as_deref(), Some("POLYMARKET"));
         assert_eq!(buy.token_id.as_deref(), Some("tok-y"));
@@ -5648,7 +5708,7 @@ mod tests {
         }"#;
         let p: ArbPosition = serde_json::from_str(json).unwrap();
         assert_eq!(p.id, "ap-1");
-        assert_eq!(p.status.as_deref(), Some("OPEN"));
+        assert_eq!(p.status, Some(ArbPositionStatus::Open));
         assert_eq!(p.buy_price.as_deref(), Some("0.55"));
         assert_eq!(p.entry_spread_pct.as_deref(), Some("0.07"));
         assert_eq!(p.unrealized_pnl.as_deref(), Some("2.50"));
@@ -5667,7 +5727,7 @@ mod tests {
     fn test_arb_close_response_deserializes() {
         let json = r#"{"status":"CLOSING","positionId":"ap-1"}"#;
         let r: ArbCloseResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(r.status.as_deref(), Some("CLOSING"));
+        assert_eq!(r.status, Some(ArbPositionStatus::Closing));
         assert_eq!(r.position_id.as_deref(), Some("ap-1"));
     }
 
@@ -5684,7 +5744,7 @@ mod tests {
         assert_eq!(d.pending_positions, 1);
         assert_eq!(d.net_exposure.polymarket, 750.0);
         assert_eq!(d.net_exposure.kalshi, -750.0);
-        assert_eq!(d.positions_by_status.get("OPEN"), Some(&3));
+        assert_eq!(d.positions_by_status.get(&ArbPositionStatus::Open), Some(&3));
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -177,7 +177,22 @@ fn validate_arb_match_id(value: &str) -> Result<()> {
             value.len()
         )));
     }
+    if !is_uuid_like(value) {
+        return Err(PolyforgeError::Validation(format!(
+            "match_id must be a valid UUID, got {value}"
+        )));
+    }
     Ok(())
+}
+
+fn is_uuid_like(value: &str) -> bool {
+    if value.len() != 36 {
+        return false;
+    }
+    value.bytes().enumerate().all(|(idx, byte)| match idx {
+        8 | 13 | 18 | 23 => byte == b'-',
+        _ => byte.is_ascii_hexdigit(),
+    })
 }
 
 /// Reject slippage outside the server-enforced `0..=5` percent range.
@@ -5564,10 +5579,10 @@ mod tests {
 
     #[test]
     fn test_validate_arb_match_id_bounds() {
-        assert!(validate_arb_match_id("m").is_ok());
-        assert!(validate_arb_match_id(&"x".repeat(255)).is_ok());
+        assert!(validate_arb_match_id("550e8400-e29b-41d4-a716-446655440000").is_ok());
         assert!(validate_arb_match_id("").is_err());
         assert!(validate_arb_match_id(&"x".repeat(256)).is_err());
+        assert!(validate_arb_match_id("match-1").is_err());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2146,9 +2146,9 @@ pub struct CreateArbitrageAlertParams {
 
 /// Parameters for `POST /api/v1/arbitrage/execute`.
 ///
-/// `match_id` must be 1..=255 characters, `size` must be an integer USDC amount
-/// in the `1..=10000` range, and `max_slippage_pct`, if set, must be in
-/// `0..=5`. These mirror the server-side `class-validator` bounds in
+/// `match_id` must be a UUID, `size` must be an integer USDC amount in the
+/// `1..=10000` range, and `max_slippage_pct`, if set, must be in `0..=5`.
+/// These mirror the server-side `class-validator` bounds in
 /// `ExecuteArbDto`. Use [`PolyforgeClient::execute_arbitrage`] which validates
 /// before any real-money order hits the wire.
 #[derive(Debug, Clone, Serialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2146,17 +2146,43 @@ pub struct CreateArbitrageAlertParams {
 
 /// Parameters for `POST /api/v1/arbitrage/execute`.
 ///
-/// `size` must be in the `1..=10000` USDC range and `max_slippage_pct`, if set,
-/// in `0..=5` — these mirror the server-side `class-validator` bounds in
+/// `match_id` must be 1..=255 characters, `size` must be an integer USDC amount
+/// in the `1..=10000` range, and `max_slippage_pct`, if set, must be in
+/// `0..=5`. These mirror the server-side `class-validator` bounds in
 /// `ExecuteArbDto`. Use [`PolyforgeClient::execute_arbitrage`] which validates
 /// before any real-money order hits the wire.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecuteArbitrageParams {
     pub match_id: String,
-    pub size: f64,
+    pub size: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_slippage_pct: Option<f64>,
+}
+
+/// Lifecycle status for a cross-venue arbitrage position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ArbPositionStatus {
+    Pending,
+    Partial,
+    Open,
+    Closing,
+    Closed,
+    Failed,
+}
+
+impl ArbPositionStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "PENDING",
+            Self::Partial => "PARTIAL",
+            Self::Open => "OPEN",
+            Self::Closing => "CLOSING",
+            Self::Closed => "CLOSED",
+            Self::Failed => "FAILED",
+        }
+    }
 }
 
 /// A single leg of an arbitrage execution result.
@@ -2188,7 +2214,7 @@ pub struct ArbExecutionResult {
     #[serde(default)]
     pub entry_spread_pct: Option<f64>,
     #[serde(default)]
-    pub status: Option<String>,
+    pub status: Option<ArbPositionStatus>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -2206,7 +2232,7 @@ pub struct ArbPosition {
     #[serde(default)]
     pub match_id: Option<String>,
     #[serde(default)]
-    pub status: Option<String>,
+    pub status: Option<ArbPositionStatus>,
 
     #[serde(default)]
     pub buy_venue: Option<String>,
@@ -2277,7 +2303,7 @@ pub struct ArbPositionsResponse {
 #[serde(rename_all = "camelCase")]
 pub struct ArbCloseResponse {
     #[serde(default)]
-    pub status: Option<String>,
+    pub status: Option<ArbPositionStatus>,
     #[serde(default)]
     pub position_id: Option<String>,
     #[serde(flatten)]
@@ -2318,7 +2344,7 @@ pub struct ArbRiskDashboard {
     #[serde(default)]
     pub avg_spread_pct: f64,
     #[serde(default)]
-    pub positions_by_status: std::collections::HashMap<String, u64>,
+    pub positions_by_status: std::collections::HashMap<ArbPositionStatus, u64>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }


### PR DESCRIPTION
## Summary
- Change ExecuteArbitrageParams.size to integer USDC and reject fractional values in validation helpers
- Add typed ArbPositionStatus and use it for arb position status responses/maps
- Add match_id and limit validation, README Arbitrage docs, and the trading-impact CHANGELOG block

## Test Plan
- cargo test --lib (282 passed)

Paperclip: POLA-1873