### PR TITLE
fix: match Polymarket response wrappers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2458,7 +2458,7 @@ impl PolyforgeClient {
     pub async fn get_polymarket_activity(
         &self,
         params: Option<&GetPolymarketActivityParams>,
-    ) -> Result<PaginatedResponse<PolymarketActivityItem>> {
+    ) -> Result<PolymarketActivityResponse> {
         let qs = match params.and_then(|p| p.activity_type.as_deref()) {
             Some(t) => format!("?type={}", encode(t)),
             None => String::new(),
@@ -6363,32 +6363,78 @@ mod tests {
 
     #[test]
     fn test_polymarket_portfolio_deserializes() {
-        let json = r#"{"positions": [], "totalValue": "1500.00"}"#;
+        let json = r#"{
+            "entries": [{
+                "asset": "tok-1",
+                "size": "50",
+                "avgPrice": "0.6",
+                "realizedPnl": "10",
+                "unrealizedPnl": "5"
+            }]
+        }"#;
         let p: PolymarketPortfolio = serde_json::from_str(json).unwrap();
-        assert_eq!(p.total_value.as_deref(), Some("1500.00"));
-        assert!(p.positions.is_empty());
+        assert_eq!(p.entries.len(), 1);
+        assert_eq!(p.entries[0].asset, "tok-1");
+        assert_eq!(p.entries[0].avg_price, "0.6");
+        assert_eq!(p.entries[0].realized_pnl, "10");
+        assert_eq!(p.entries[0].unrealized_pnl, "5");
     }
 
     #[test]
     fn test_polymarket_earnings_deserializes() {
-        let json = r#"{"total": "200.00", "realized": "150.00", "unrealized": "50.00"}"#;
+        let json = r#"{
+            "entries": [{
+                "date": "2026-01-01",
+                "earnings": "25.50",
+                "volume": "500",
+                "winRate": "0.60"
+            }]
+        }"#;
         let e: PolymarketEarnings = serde_json::from_str(json).unwrap();
-        assert_eq!(e.total.as_deref(), Some("200.00"));
-        assert_eq!(e.realized.as_deref(), Some("150.00"));
+        assert_eq!(e.entries.len(), 1);
+        assert_eq!(e.entries[0].date, "2026-01-01");
+        assert_eq!(e.entries[0].earnings, "25.50");
+        assert_eq!(e.entries[0].volume, "500");
+        assert_eq!(e.entries[0].win_rate, "0.60");
     }
 
     #[test]
     fn test_polymarket_activity_item_deserializes() {
         let json = r#"{
             "id": "act-1",
-            "type": "trade",
+            "type": "TRADE",
             "amount": "50.00",
-            "createdAt": "2025-01-15T12:00:00Z"
+            "asset": "tok-1",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "metadata": {"market": "m-1"}
         }"#;
         let item: PolymarketActivityItem = serde_json::from_str(json).unwrap();
         assert_eq!(item.id.as_deref(), Some("act-1"));
-        assert_eq!(item.activity_type.as_deref(), Some("trade"));
+        assert_eq!(item.activity_type.as_deref(), Some("TRADE"));
         assert_eq!(item.amount.as_deref(), Some("50.00"));
+        assert_eq!(item.asset.as_deref(), Some("tok-1"));
+        assert_eq!(item.timestamp.as_deref(), Some("2026-01-01T00:00:00Z"));
+        assert_eq!(item.metadata.as_ref().unwrap()["market"], "m-1");
+    }
+
+    #[test]
+    fn test_polymarket_activity_response_deserializes() {
+        let json = r#"{
+            "activities": [{
+                "id": "act-1",
+                "type": "TRADE",
+                "amount": "50.00",
+                "asset": "tok-1",
+                "timestamp": "2026-01-01T00:00:00Z"
+            }]
+        }"#;
+        let response: PolymarketActivityResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.activities.len(), 1);
+        assert_eq!(response.activities[0].id.as_deref(), Some("act-1"));
+        assert_eq!(
+            response.activities[0].activity_type.as_deref(),
+            Some("TRADE")
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1842,28 +1842,47 @@ pub struct Badge {
 // Portfolio — Polymarket-native
 // ---------------------------------------------------------------------------
 
-/// Native Polymarket portfolio snapshot.
+/// A single native Polymarket portfolio entry.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct PolymarketPortfolio {
-    #[serde(default)]
-    pub positions: Vec<serde_json::Value>,
-    #[serde(default)]
-    pub total_value: Option<String>,
+pub struct PolymarketPortfolioEntry {
+    pub asset: String,
+    pub size: String,
+    pub avg_price: String,
+    pub realized_pnl: String,
+    pub unrealized_pnl: String,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
 
-/// Native Polymarket earnings summary.
+/// Native Polymarket portfolio response.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PolymarketPortfolio {
+    #[serde(default)]
+    pub entries: Vec<PolymarketPortfolioEntry>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// A single native Polymarket earnings entry.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PolymarketEarningsEntry {
+    pub date: String,
+    pub earnings: String,
+    pub volume: String,
+    pub win_rate: String,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Native Polymarket earnings response.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PolymarketEarnings {
     #[serde(default)]
-    pub total: Option<String>,
-    #[serde(default)]
-    pub realized: Option<String>,
-    #[serde(default)]
-    pub unrealized: Option<String>,
+    pub entries: Vec<PolymarketEarningsEntry>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -1878,8 +1897,24 @@ pub struct PolymarketActivityItem {
     pub activity_type: Option<String>,
     #[serde(default)]
     pub amount: Option<String>,
+    #[serde(default)]
+    pub asset: Option<String>,
+    #[serde(default)]
+    pub timestamp: Option<String>,
     #[serde(rename = "createdAt", default)]
     pub created_at: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Native Polymarket activity response.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PolymarketActivityResponse {
+    #[serde(default)]
+    pub activities: Vec<PolymarketActivityItem>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -1887,7 +1922,7 @@ pub struct PolymarketActivityItem {
 /// Query parameters for the Polymarket activity endpoint.
 #[derive(Debug, Default)]
 pub struct GetPolymarketActivityParams {
-    /// Activity type filter, e.g. `"trade"`, `"deposit"`, `"withdrawal"`.
+    /// Activity type filter, e.g. `"TRADE"`, `"SPLIT"`, or `"REDEEM"`.
     pub activity_type: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- Model Polymarket portfolio and earnings responses as platform wrappers with `entries` arrays
- Add `PolymarketActivityResponse` and return it from `get_polymarket_activity()` instead of `PaginatedResponse`
- Update deserialization regression tests for the platform `entries` / `activities` payloads

## Verification
- `cargo fmt --check`
- `cargo test polymarket --lib` (5 passed)
- `cargo test` (359 unit tests + 4 doctests passed)
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- Added-line security scan: no hardcoded secret / shell injection / eval / unsafe deserialization / SQL-injection patterns
- GitNexus impact: LOW for touched Polymarket response symbols and activity method
- GitNexus detect-changes: 2 files, 0 affected processes, low risk

Closes #196