### PR TITLE
fix: omit marketId from place order params

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3630,7 +3630,6 @@ mod tests {
     #[test]
     fn test_place_order_params_validation_rejects_nan_size() {
         let params = PlaceOrderParams {
-            market_id: "m1".into(),
             token_id: "t1".into(),
             side: "BUY".into(),
             outcome: "YES".into(),
@@ -3648,7 +3647,6 @@ mod tests {
     #[test]
     fn test_place_order_params_validation_rejects_negative_price() {
         let params = PlaceOrderParams {
-            market_id: "m1".into(),
             token_id: "t1".into(),
             side: "BUY".into(),
             outcome: "YES".into(),
@@ -3664,9 +3662,8 @@ mod tests {
     }
 
     #[test]
-    fn test_place_order_params_serializes_market_id() {
+    fn test_place_order_params_omits_market_id() {
         let params = PlaceOrderParams {
-            market_id: "mkt-abc".into(),
             token_id: "tok-1".into(),
             side: "BUY".into(),
             outcome: "YES".into(),
@@ -3675,11 +3672,10 @@ mod tests {
             order_type: None,
         };
         let json = serde_json::to_value(&params).unwrap();
-        assert_eq!(json["marketId"], "mkt-abc");
         assert_eq!(json["tokenId"], "tok-1");
         assert!(
-            json.get("market_id").is_none(),
-            "must use camelCase marketId"
+            json.get("marketId").is_none(),
+            "platform derives marketId from tokenId and rejects explicit marketId"
         );
         assert!(
             json.get("orderType").is_none(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -533,8 +533,6 @@ pub struct MergePositionParams {
 /// Parameters for placing a direct order.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlaceOrderParams {
-    #[serde(rename = "marketId")]
-    pub market_id: String,
     #[serde(rename = "tokenId")]
     pub token_id: String,
     pub side: String,


### PR DESCRIPTION
## Summary
- Remove serialized `marketId` from `PlaceOrderParams` so order bodies match the platform contract.
- Replace the old serialization regression with coverage asserting `marketId` is omitted.

## Verification
- RED: `cargo test test_place_order_params_omits_market_id -- --nocapture` failed before the struct change because `marketId` was still present.
- GREEN: `cargo test test_place_order_params -- --nocapture` passed (3 tests).
- `cargo test --lib` passed (288 tests).
- `cargo test` passed (288 unit tests, 4 doc tests).
- `git diff --check` passed.

## Notes
- `cargo fmt --check` still reports existing unrelated whole-file formatting drift in `src/client.rs` and `src/types.rs`; this PR leaves that churn untouched.
- GitNexus impact for `PlaceOrderParams`: LOW risk, 3 direct test callers, 2 affected test processes, 1 module.
- `gitnexus_detect_changes` is not exposed in this Codex runtime and the local `gitnexus` CLI has no `detect_changes` command, so final scope was checked with GitNexus impact plus `git diff`.

Closes #192