### PR TITLE
fix: validate batch order financial params

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1647,7 +1647,15 @@ impl PolyforgeClient {
     ///
     /// The SDK automatically sends an `Idempotency-Key` header required by the
     /// platform for trading writes.
+    ///
+    /// # Errors
+    /// Returns [`PolyforgeError::Validation`] if any order `size` or `price` is
+    /// NaN, infinite, zero, or negative.
     pub async fn batch_orders(&self, params: &BatchOrdersParams) -> Result<BatchOrdersResponse> {
+        for (index, order) in params.orders.iter().enumerate() {
+            validate_financial_param(&format!("orders[{index}].size"), order.size)?;
+            validate_financial_param(&format!("orders[{index}].price"), order.price)?;
+        }
         let body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
         self.post_idempotent("/api/v1/orders/batch", &body).await
     }
@@ -4582,6 +4590,52 @@ mod tests {
         let err = rt.block_on(client.place_order(&params)).unwrap_err();
         assert!(matches!(err, PolyforgeError::Validation(_)));
         assert!(err.to_string().contains("price"));
+    }
+
+    #[test]
+    fn test_batch_orders_validation_rejects_invalid_size_values() {
+        let invalid_values = [f64::NAN, f64::INFINITY, 0.0, -1.0];
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let client = PolyforgeClient::with_url("test-key", "http://127.0.0.1:9").unwrap();
+
+        for size in invalid_values {
+            let params = BatchOrdersParams {
+                orders: vec![PlaceOrderParams {
+                    token_id: "t1".into(),
+                    side: "BUY".into(),
+                    outcome: "YES".into(),
+                    size,
+                    price: 0.5,
+                    order_type: None,
+                }],
+            };
+            let err = rt.block_on(client.batch_orders(&params)).unwrap_err();
+            assert!(matches!(err, PolyforgeError::Validation(_)));
+            assert!(err.to_string().contains("orders[0].size"));
+        }
+    }
+
+    #[test]
+    fn test_batch_orders_validation_rejects_invalid_price_values() {
+        let invalid_values = [f64::NAN, f64::INFINITY, 0.0, -1.0];
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let client = PolyforgeClient::with_url("test-key", "http://127.0.0.1:9").unwrap();
+
+        for price in invalid_values {
+            let params = BatchOrdersParams {
+                orders: vec![PlaceOrderParams {
+                    token_id: "t1".into(),
+                    side: "BUY".into(),
+                    outcome: "YES".into(),
+                    size: 10.0,
+                    price,
+                    order_type: None,
+                }],
+            };
+            let err = rt.block_on(client.batch_orders(&params)).unwrap_err();
+            assert!(matches!(err, PolyforgeError::Validation(_)));
+            assert!(err.to_string().contains("orders[0].price"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Validates every `batch_orders` order `size` and `price` with the existing positive finite financial validator before JSON serialization or network I/O.
- Adds regression coverage for NaN, infinity, zero, and negative `size`/`price` values with indexed error fields like `orders[0].size`.

## Verification
- Red check: temporarily removed the batch validation guard; `cargo test batch_orders_validation --lib` failed both new validation tests on `PolyforgeError::Validation` assertions.
- `cargo test batch_orders_validation --lib` passed: 2 passed.
- `cargo test --lib` passed: 291 passed.
- `cargo test` passed: 291 unit tests and 4 doc tests passed.
- `git diff --cached --check` passed before commit.

## Notes
- Rebased onto current `origin/master` and preserved the current `PlaceOrderParams` shape that omits `marketId`.
- `cargo fmt --check` currently reports pre-existing formatting drift outside this one-file fix; I did not apply a broad format-only change.
- GitNexus impact: `batch_orders` LOW risk, no indexed callers/processes. `validate_financial_param` itself is CRITICAL/shared, but this PR does not change its implementation.
- GitNexus `detect_changes` was unavailable in this runtime/CLI surface, so scope was checked with staged diff/stat and the refreshed GitNexus index after commit.

Closes #194
