### PR TITLE
fix: hide admin-only arbitrage match mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@
   wraps the route as-is for fidelity; a server-side fix is tracked separately.
 
 ### Fixed
+- **Admin-only arbitrage match mutations** — hide `create_arbitrage_match`,
+  `verify_arbitrage_match`, `delete_arbitrage_match`, and
+  `sync_arbitrage_matches` from the public Rustdoc surface and deprecate them
+  with an explicit admin-only note. The wrappers remain temporarily for source
+  compatibility, but ordinary public API keys still receive `403 Forbidden`.
 - **NotificationSettings / UpdateNotificationSettingsParams** — rewrite both structs to mirror the platform's `UpdateNotificationsDto`. Removes fictional fields (`pushEnabled`, `orderFills`, `strategyErrors`, `whaleAlerts`, `marketResolutions`, `dailySummary`) that the platform rejected with 400 under `forbidNonWhitelisted: true`, and adds the real DTO fields (`telegramEnabled`, `discordEnabled`, `onOrderFilled`, `onStrategyError`, `onBacktestComplete`, `onDailyLossLimit`, `onMarketResolved`, `onSomeoneForked`, `onSomeoneFollowed`, `onSomeoneLiked`, `onSomeoneCommented`). The `extra` flatten bucket is preserved on the read struct so server-only fields (`userId`, `updatedAt`, `eventPrefs`, `emailDigest`, `notificationFreq`, `minFillNotifyUsdc`, `onTicketReply`) round-trip. Added a wire-format key-set test. (closes #184)
 
 ## [1.7.6] — 2026-04-25

--- a/src/client.rs
+++ b/src/client.rs
@@ -2783,7 +2783,14 @@ impl PolyforgeClient {
         self.get(&path).await
     }
 
-    /// Create a new arbitrage match between a Polymarket and Kalshi market.
+    /// Admin-only: create a new arbitrage match between a Polymarket and Kalshi market.
+    ///
+    /// Requires an admin JWT/AdminRole on the platform. Ordinary public SDK API
+    /// keys receive `403 Forbidden`.
+    #[doc(hidden)]
+    #[deprecated(
+        note = "admin-only endpoint; requires an admin JWT/AdminRole and ordinary public API keys receive 403"
+    )]
     pub async fn create_arbitrage_match(
         &self,
         params: &CreateArbitrageMatchParams,
@@ -2792,19 +2799,40 @@ impl PolyforgeClient {
             .await
     }
 
-    /// Verify an arbitrage match (admin action).
+    /// Admin-only: verify an arbitrage match.
+    ///
+    /// Requires an admin JWT/AdminRole on the platform. Ordinary public SDK API
+    /// keys receive `403 Forbidden`.
+    #[doc(hidden)]
+    #[deprecated(
+        note = "admin-only endpoint; requires an admin JWT/AdminRole and ordinary public API keys receive 403"
+    )]
     pub async fn verify_arbitrage_match(&self, match_id: &str) -> Result<ArbitrageMatch> {
         let path = format!("/api/v1/arbitrage/matches/{}/verify", encode(match_id));
         self.post(&path, &json!({})).await
     }
 
-    /// Delete an arbitrage match.
+    /// Admin-only: delete an arbitrage match.
+    ///
+    /// Requires an admin JWT/AdminRole on the platform. Ordinary public SDK API
+    /// keys receive `403 Forbidden`.
+    #[doc(hidden)]
+    #[deprecated(
+        note = "admin-only endpoint; requires an admin JWT/AdminRole and ordinary public API keys receive 403"
+    )]
     pub async fn delete_arbitrage_match(&self, match_id: &str) -> Result<()> {
         let path = format!("/api/v1/arbitrage/matches/{}", encode(match_id));
         self.delete(&path).await
     }
 
-    /// Trigger a sync of arbitrage matches from external sources.
+    /// Admin-only: trigger a sync of arbitrage matches from external sources.
+    ///
+    /// Requires an admin JWT/AdminRole on the platform. Ordinary public SDK API
+    /// keys receive `403 Forbidden`.
+    #[doc(hidden)]
+    #[deprecated(
+        note = "admin-only endpoint; requires an admin JWT/AdminRole and ordinary public API keys receive 403"
+    )]
     pub async fn sync_arbitrage_matches(&self) -> Result<MatchSyncResult> {
         self.post("/api/v1/arbitrage/matches/sync", &json!({}))
             .await
@@ -6579,6 +6607,36 @@ mod tests {
         };
         let v = serde_json::to_value(&p).unwrap();
         assert!(v.get("notes").is_none());
+    }
+
+    #[test]
+    fn test_admin_only_arbitrage_match_mutations_are_hidden_and_deprecated() {
+        let source = include_str!("client.rs");
+        for method in [
+            "create_arbitrage_match",
+            "verify_arbitrage_match",
+            "delete_arbitrage_match",
+            "sync_arbitrage_matches",
+        ] {
+            let method_pos = source
+                .find(&format!("pub async fn {method}"))
+                .unwrap_or_else(|| panic!("{method} should exist for compatibility"));
+            let prefix_start = source[..method_pos].rfind("\n\n").map_or(0, |idx| idx + 2);
+            let prefix = &source[prefix_start..method_pos];
+
+            assert!(
+                prefix.contains("#[doc(hidden)]"),
+                "{method} must be hidden from the public Rustdoc surface"
+            );
+            assert!(
+                prefix.contains("#[deprecated(") && prefix.contains("admin-only"),
+                "{method} must be deprecated with an admin-only note"
+            );
+            assert!(
+                prefix.contains("Admin-only"),
+                "{method} docs must explicitly say the endpoint is admin-only"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Hide Rust SDK arbitrage match mutation wrappers from Rustdoc with `#[doc(hidden)]`.
- Deprecate `create_arbitrage_match`, `verify_arbitrage_match`, `delete_arbitrage_match`, and `sync_arbitrage_matches` with explicit admin-only notes.
- Add regression coverage that locks the hidden/deprecated/admin-only surface contract.

## Context
Blocks F4CTE/PolyForge#1234 and Paperclip POLA-2152/POLA-2555.

## Verification
- `cargo test` (322 unit tests + 4 doc tests)
- `cargo build`
- `cargo clippy -- -D warnings`
- `cargo doc --no-deps` passes with existing `PolyforgeClient::start_strategy` rustdoc link warning
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps` fails on the pre-existing broken intra-doc link in `src/types.rs:181`
- `rg "create_arbitrage_match|verify_arbitrage_match|delete_arbitrage_match|sync_arbitrage_matches" target/doc/polyforge -g '*.html'` returns no matches
- GitNexus impact before edit: LOW for all four touched methods, zero direct callers/processes
- GitNexus detect-changes: medium, 2 files / 11 symbols / 4 affected flows
