### PR TITLE
fix(sdk-rust): POLA-1913 polish — auth_header optional, decimal precision, naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@
   32 new unit tests cover URL paths, query/body camelCase serialization, validation bounds (size/price/non-finite inputs), enum casing, envelope handling, nullable sentiment votes, and JSON deserialization shapes. `cargo build`, `cargo clippy -- -D warnings`, and `cargo test` (321 unit tests plus 4 doc tests passing) are clean.
 
 ### Notes
+- Public user/profile lookup methods no longer send an `Authorization` header when
+  the client was constructed with an empty API key. This keeps documented public
+  endpoints usable without credentials while preserving authenticated behavior
+  when a key is configured. Added multi-chunk coverage for the 1-MiB error body
+  cap and documented that exactly 1 MiB is allowed while the first byte over the
+  limit is rejected.
 - `GET /sports/combos/:collectionTicker` currently ignores its path param
   server-side (forwards to `listComboCollections({page:1, limit:1})`). The SDK
   wraps the route as-is for fidelity; a server-side fix is tracked separately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@
   - `get_arbitrage_risk_dashboard()` → `GET /api/v1/arbitrage/risk/dashboard`.
   - `get_arbitrage_settlement_risks()` → `GET /api/v1/arbitrage/risk/settlement`.
   - `refresh_arbitrage_pnl()` → `POST /api/v1/arbitrage/risk/refresh-pnl`.
-- New types: `ExecuteArbitrageParams`, `ArbPositionStatus`, `ArbExecutionLeg`, `ArbExecutionResult`, `ArbPosition`, `ArbPositionsResponse`, `ArbCloseResponse`, `ArbNetExposure`, `ArbRiskDashboard`, `ArbSettlementRisk`, `ArbPnlRefreshResult`. Decimal columns (`buy_price`, `sell_price`, P&L, spread) are typed as `Option<String>` to preserve full precision from the backend Prisma `Decimal` serialization, matching the Python SDK shape.
+- New types: `ExecuteArbitrageParams`, `ArbPositionStatus`, `ArbExecutionLeg`, `ArbExecutionResult`, `ArbPosition`, `ArbPositionsResponse`, `ArbCloseResponse`, `ArbNetExposure`, `ArbRiskDashboard`, `ArbSettlementRisk`, `ArbPnlRefreshResult`. Decimal columns (`ArbExecutionLeg.price`, `buy_price`, `sell_price`, P&L, spread) are typed as `Option<String>` to preserve full precision from the backend Prisma `Decimal` serialization, matching the Python SDK shape.
 
 ### ⚠️ Trading impact (severity: HIGH)
 - `execute_arbitrage()` and `close_arbitrage_position()` can place real offsetting orders. Callers must supply an idempotency key for safe retries; the SDK sends it as `Idempotency-Key` and fails fast on missing/invalid keys, malformed `match_id`, fractional or out-of-range `size`, invalid slippage, invalid position status filters, and oversized page limits before requests reach the trading API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@
   when a key is configured. Added multi-chunk coverage for the 1-MiB error body
   cap and documented that exactly 1 MiB is allowed while the first byte over the
   limit is rejected.
+- Cross-SDK naming aliases: `get_notifications()` is now a deprecated alias for
+  `list_notifications()`, and `ReferralsInfo` is now a deprecated alias for the
+  canonical `MyReferralsResponse` type.
 - `GET /sports/combos/:collectionTicker` currently ignores its path param
   server-side (forwards to `listComboCollections({page:1, limit:1})`). The SDK
   wraps the route as-is for fidelity; a server-side fix is tracked separately.

--- a/src/client.rs
+++ b/src/client.rs
@@ -6720,8 +6720,8 @@ mod tests {
     fn test_arb_execution_result_deserializes() {
         let json = r#"{
             "arbPositionId":"ap-1",
-            "buyLeg":{"venue":"POLYMARKET","intentId":"b-1","tokenId":"tok-y","price":0.55},
-            "sellLeg":{"venue":"KALSHI","intentId":"s-1","tokenId":"tok-n","price":0.48},
+            "buyLeg":{"venue":"POLYMARKET","intentId":"b-1","tokenId":"tok-y","price":"0.550000000000000000"},
+            "sellLeg":{"venue":"KALSHI","intentId":"s-1","tokenId":"tok-n","price":"0.480000000000000000"},
             "entrySpreadPct":0.07,
             "status":"PENDING"
         }"#;
@@ -6732,6 +6732,7 @@ mod tests {
         let buy = r.buy_leg.as_ref().unwrap();
         assert_eq!(buy.venue.as_deref(), Some("POLYMARKET"));
         assert_eq!(buy.token_id.as_deref(), Some("tok-y"));
+        assert_eq!(buy.price.as_deref(), Some("0.550000000000000000"));
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -6736,6 +6736,22 @@ mod tests {
     }
 
     #[test]
+    fn test_arb_execution_result_deserializes_numeric_leg_prices() {
+        let json = r#"{
+            "arbPositionId":"ap-1",
+            "buyLeg":{"venue":"POLYMARKET","intentId":"b-1","tokenId":"tok-y","price":0.55},
+            "sellLeg":{"venue":"KALSHI","intentId":"s-1","tokenId":"tok-n","price":0.48},
+            "entrySpreadPct":0.07,
+            "status":"PENDING"
+        }"#;
+        let r: ArbExecutionResult = serde_json::from_str(json).unwrap();
+        let buy = r.buy_leg.as_ref().unwrap();
+        let sell = r.sell_leg.as_ref().unwrap();
+        assert_eq!(buy.price.as_deref(), Some("0.55"));
+        assert_eq!(sell.price.as_deref(), Some("0.48"));
+    }
+
+    #[test]
     fn test_arb_position_deserializes_with_decimal_strings() {
         let json = r#"{
             "id":"ap-1","userId":"u-1","matchId":"m-1","status":"OPEN",

--- a/src/client.rs
+++ b/src/client.rs
@@ -3196,9 +3196,18 @@ impl PolyforgeClient {
         self.get(&format!("/api/v1/notifications{qs}")).await
     }
 
+    /// Deprecated alias for [`Self::list_notifications`].
+    #[deprecated(note = "use list_notifications instead")]
+    pub async fn get_notifications(
+        &self,
+        params: Option<&PaginationParams>,
+    ) -> Result<PaginatedResponse<Notification>> {
+        self.list_notifications(params).await
+    }
+
     /// Fetch the authenticated user's referral code, link, and stats
     /// (`GET /api/v1/referrals/me`).
-    pub async fn get_my_referrals(&self) -> Result<ReferralsInfo> {
+    pub async fn get_my_referrals(&self) -> Result<MyReferralsResponse> {
         self.get("/api/v1/referrals/me").await
     }
 
@@ -7837,7 +7846,26 @@ mod tests {
     }
 
     #[test]
-    fn test_referrals_info_deserializes() {
+    fn test_my_referrals_response_deserializes() {
+        let json = serde_json::json!({
+            "referralCode": "ABCD1234",
+            "referralLink": "https://polyforge.trade/ref/ABCD1234",
+            "stats": {
+                "invited": 1,
+                "signedUp": 0,
+                "active": 0,
+                "creditsEarned": 0
+            },
+            "referrals": []
+        });
+        let info: MyReferralsResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(info.referral_code.as_deref(), Some("ABCD1234"));
+        assert_eq!(info.stats.as_ref().unwrap().invited, 1);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_deprecated_referrals_alias_deserializes() {
         let json = serde_json::json!({
             "referralCode": "ABCD1234",
             "referralLink": "https://polyforge.trade/ref/ABCD1234",
@@ -7852,6 +7880,14 @@ mod tests {
         let info: ReferralsInfo = serde_json::from_value(json).unwrap();
         assert_eq!(info.referral_code.as_deref(), Some("ABCD1234"));
         assert_eq!(info.stats.as_ref().unwrap().invited, 1);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_deprecated_get_notifications_alias_compiles() {
+        let client = PolyforgeClient::new("k").unwrap();
+        let future = client.get_notifications(None);
+        drop(future);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -408,6 +408,13 @@ impl PolyforgeClient {
         })
     }
 
+    fn optional_auth_header(&self) -> Result<Option<HeaderValue>> {
+        if self.api_key.expose_secret().is_empty() {
+            return Ok(None);
+        }
+        self.auth_header().map(Some)
+    }
+
     async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
         let resp = self
             .http
@@ -415,6 +422,18 @@ impl PolyforgeClient {
             .header(AUTHORIZATION, self.auth_header()?)
             .send()
             .await?;
+        self.handle_response(resp).await
+    }
+
+    async fn get_with_optional_auth<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+    ) -> Result<T> {
+        let mut req = self.http.get(self.url(path));
+        if let Some(auth_header) = self.optional_auth_header()? {
+            req = req.header(AUTHORIZATION, auth_header);
+        }
+        let resp = req.send().await?;
         self.handle_response(resp).await
     }
 
@@ -526,6 +545,7 @@ impl PolyforgeClient {
         serde_json::from_str(&body).map_err(PolyforgeError::from)
     }
 
+    /// Read an error response body, allowing bodies exactly 1 MiB and rejecting the first byte over.
     async fn read_error_body(
         mut resp: reqwest::Response,
         status: u16,
@@ -1227,13 +1247,13 @@ impl PolyforgeClient {
 
     /// Get the score for a specific user.
     pub async fn get_user_score(&self, user_id: &str) -> Result<TraderScore> {
-        self.get(&format!("/api/v1/scores/{}", encode(user_id)))
+        self.get_with_optional_auth(&format!("/api/v1/scores/{}", encode(user_id)))
             .await
     }
 
     /// Get the badges awarded to a specific user.
     pub async fn get_user_badges(&self, user_id: &str) -> Result<Vec<Badge>> {
-        self.get(&format!("/api/v1/scores/{}/badges", encode(user_id)))
+        self.get_with_optional_auth(&format!("/api/v1/scores/{}/badges", encode(user_id)))
             .await
     }
 
@@ -1252,7 +1272,7 @@ impl PolyforgeClient {
         period: &str,
     ) -> Result<Vec<UserPerformancePoint>> {
         let res: UserDataEnvelope<UserPerformancePoint> = self
-            .get(&format!(
+            .get_with_optional_auth(&format!(
                 "/api/v1/users/{}/performance?period={}",
                 encode(username),
                 encode(period)
@@ -1287,7 +1307,7 @@ impl PolyforgeClient {
             format!("?{}", pairs.join("&"))
         };
         let res: UserDataEnvelope<UserStrategySummary> = self
-            .get(&format!(
+            .get_with_optional_auth(&format!(
                 "/api/v1/users/{}/strategies{}",
                 encode(username),
                 qs
@@ -1308,7 +1328,7 @@ impl PolyforgeClient {
             None => String::new(),
         };
         let res: UserDataEnvelope<UserActivityEntry> = self
-            .get(&format!(
+            .get_with_optional_auth(&format!(
                 "/api/v1/users/{}/activity{}",
                 encode(username),
                 qs
@@ -1320,7 +1340,7 @@ impl PolyforgeClient {
     /// Badges earned by a public user (id is the badge type).
     pub async fn get_user_profile_badges(&self, username: &str) -> Result<Vec<UserProfileBadge>> {
         let res: UserDataEnvelope<UserProfileBadge> = self
-            .get(&format!("/api/v1/users/{}/badges", encode(username)))
+            .get_with_optional_auth(&format!("/api/v1/users/{}/badges", encode(username)))
             .await?;
         Ok(res.data)
     }
@@ -2958,7 +2978,7 @@ impl PolyforgeClient {
     /// Get a public user profile by username.
     pub async fn get_user_profile(&self, username: &str) -> Result<UserProfile> {
         let path = format!("/api/v1/profile/{}", encode(username));
-        self.get(&path).await
+        self.get_with_optional_auth(&path).await
     }
 
     /// Follow a user by username.
@@ -3460,6 +3480,67 @@ mod tests {
             name.eq_ignore_ascii_case(header_name)
                 .then(|| value.trim().to_string())
         })
+    }
+
+    #[test]
+    fn test_client_optional_auth_header_omits_empty_key() {
+        let client = PolyforgeClient::new("").unwrap();
+        assert!(client.optional_auth_header().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_public_user_endpoints_dispatch_without_api_key() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            for _ in 0..7 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0_u8; 4096];
+                let n = socket.read(&mut request).await.unwrap();
+                let request = String::from_utf8_lossy(&request[..n]);
+                assert!(
+                    !request.to_ascii_lowercase().contains("authorization:"),
+                    "public profile request unexpectedly included Authorization header: {request}"
+                );
+                let body = if request.contains("/api/v1/scores/") && request.contains("/badges") {
+                    "[]"
+                } else if request.contains("/api/v1/scores/") {
+                    "{}"
+                } else if request.contains("/api/v1/profile/") {
+                    "{}"
+                } else {
+                    "{\"data\":[]}"
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\n\
+                     content-type: application/json\r\n\
+                     content-length: {}\r\n\
+                     connection: close\r\n\
+                     \r\n\
+                     {}",
+                    body.len(),
+                    body
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let client = PolyforgeClient::with_url("", format!("http://{addr}")).unwrap();
+        client.get_user_score("alice").await.unwrap();
+        client.get_user_badges("alice").await.unwrap();
+        client.get_user_performance("alice", "30d").await.unwrap();
+        client
+            .get_user_strategies("alice", None, None)
+            .await
+            .unwrap();
+        client.get_user_activity("alice", None).await.unwrap();
+        client.get_user_profile_badges("alice").await.unwrap();
+        client.get_user_profile("alice").await.unwrap();
+
+        server.await.unwrap();
     }
 
     #[test]
@@ -4054,6 +4135,58 @@ mod tests {
                 assert_eq!(status, 500);
             }
             other => panic!(
+                "Expected Api error with RESPONSE_BODY_TOO_LARGE, got: {:?}",
+                other
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_rejects_multichunk_oversized_error_body_without_content_length() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let first_chunk = vec![b'x'; 700 * 1024];
+        let second_chunk = vec![b'y'; 700 * 1024];
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await;
+            socket
+                .write_all(
+                    b"HTTP/1.1 500 Internal Server Error\r\n\
+                      content-type: application/json\r\n\
+                      connection: close\r\n\
+                      \r\n",
+                )
+                .await
+                .unwrap();
+            socket.write_all(&first_chunk).await.unwrap();
+            socket.write_all(&second_chunk).await.unwrap();
+        });
+
+        let client = PolyforgeClient::with_url("test-key", format!("http://{addr}")).unwrap();
+        let result: std::result::Result<serde_json::Value, _> =
+            client.get("/multi-chunk-error").await;
+
+        match result {
+            Err(PolyforgeError::Api {
+                code,
+                status,
+                message,
+                ..
+            }) => {
+                assert_eq!(code, "RESPONSE_BODY_TOO_LARGE");
+                assert_eq!(status, 500);
+                assert!(
+                    message.contains("limit 1048576"),
+                    "message should include the exact truncation limit: {message}"
+                );
+            }
+            Ok(_) => panic!("Expected Api error with RESPONSE_BODY_TOO_LARGE"),
+            Err(other) => panic!(
                 "Expected Api error with RESPONSE_BODY_TOO_LARGE, got: {:?}",
                 other
             ),

--- a/src/types.rs
+++ b/src/types.rs
@@ -2142,9 +2142,9 @@ pub struct CreateArbitrageAlertParams {
 //   - `GET  /api/v1/arbitrage/risk/settlement`    — resolution-criteria mismatches
 //   - `POST /api/v1/arbitrage/risk/refresh-pnl`   — recompute unrealized P&L
 //
-// Decimal columns (sizes, prices, P&L) arrive as JSON strings from Prisma; we
-// keep them as `Option<String>` so callers can convert with full precision
-// rather than relying on f64 coercion. Mirrors the Python SDK shapes.
+// Decimal columns (sizes, prices, P&L) generally arrive as JSON strings from
+// Prisma; we keep them as `Option<String>` so callers can convert with full
+// precision rather than relying on f64 coercion. Mirrors the Python SDK shapes.
 
 /// Parameters for `POST /api/v1/arbitrage/execute`.
 ///
@@ -2187,6 +2187,22 @@ impl ArbPositionStatus {
     }
 }
 
+fn deserialize_optional_string_or_number<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<serde_json::Value>::deserialize(deserializer)? {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(value)) => Ok(Some(value)),
+        Some(serde_json::Value::Number(value)) => Ok(Some(value.to_string())),
+        Some(value) => Err(serde::de::Error::custom(format!(
+            "expected string, number, or null, got {value}"
+        ))),
+    }
+}
+
 /// A single leg of an arbitrage execution result.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -2197,7 +2213,7 @@ pub struct ArbExecutionLeg {
     pub intent_id: Option<String>,
     #[serde(default)]
     pub token_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_string_or_number")]
     pub price: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2950,7 +2950,7 @@ pub struct ReferralStats {
 /// Response of `GET /api/v1/referrals/me`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ReferralsInfo {
+pub struct MyReferralsResponse {
     #[serde(default)]
     pub referral_code: Option<String>,
     #[serde(default)]
@@ -2962,6 +2962,9 @@ pub struct ReferralsInfo {
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
+
+#[deprecated(note = "use MyReferralsResponse instead")]
+pub use self::MyReferralsResponse as ReferralsInfo;
 
 /// Side of an order preview request — `BUY` or `SELL`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2198,7 +2198,7 @@ pub struct ArbExecutionLeg {
     #[serde(default)]
     pub token_id: Option<String>,
     #[serde(default)]
-    pub price: Option<f64>,
+    pub price: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }


### PR DESCRIPTION
## Summary
- allow public user/profile endpoints to dispatch without an API key by omitting Authorization when the configured key is empty
- preserve `ArbExecutionLeg.price` as `Option<String>` for lossless decimal payloads
- add cross-SDK naming aliases: deprecated `get_notifications()` and deprecated `ReferralsInfo` alias for `MyReferralsResponse`
- document the 1 MiB error-body boundary and cover multi-chunk oversized error bodies

## Verification
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo fmt --check`

Closes POLA-1913 (partial)