### PR TITLE
fix: require JWT auth for get_user_score, get_user_badges, get_user_profile (closes #211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
 
 ### Changed
 - **`get_user_score`, `get_user_badges`, `get_user_profile` now require authentication.** These methods previously used optional auth but the platform requires a valid JWT for `GET /api/v1/scores/{userId}`, `GET /api/v1/scores/{userId}/badges`, and `GET /api/v1/profile/{username}`. They now use mandatory auth to match the platform's auth requirements. (closes #211)
+- **`get_actions` switched to optional auth.** The platform's actions controller is unguarded, so `get_actions` now uses `get_with_optional_auth()` so the method works even when the client is constructed without an API key.
+- **Docstrings updated** for `get_user_score`, `get_user_badges`, `get_user_profile` to clarify they require authentication.
 
 ### Fixed
 - **Trading writes** — automatically attach a fresh `Idempotency-Key` header to order, bulk order, liquidity, position, smart-order, and conditional-order mutations so platform idempotency validation no longer rejects Rust SDK writes with `MISSING_IDEMPOTENCY_KEY`. (closes #197)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,14 +43,14 @@
 
   32 new unit tests cover URL paths, query/body camelCase serialization, validation bounds (size/price/non-finite inputs), enum casing, envelope handling, nullable sentiment votes, and JSON deserialization shapes. `cargo build`, `cargo clippy -- -D warnings`, and `cargo test` (321 unit tests plus 4 doc tests passing) are clean.
 
+### Changed
+- **`get_user_score`, `get_user_badges`, `get_user_profile` now require authentication.** These methods previously used optional auth but the platform requires a valid JWT for `GET /api/v1/scores/{userId}`, `GET /api/v1/scores/{userId}/badges`, and `GET /api/v1/profile/{username}`. They now use mandatory auth to match the platform's auth requirements. (closes #211)
+
 ### Fixed
 - **Trading writes** — automatically attach a fresh `Idempotency-Key` header to order, bulk order, liquidity, position, smart-order, and conditional-order mutations so platform idempotency validation no longer rejects Rust SDK writes with `MISSING_IDEMPOTENCY_KEY`. (closes #197)
 
 ### Notes
-- Public user/profile lookup methods no longer send an `Authorization` header when
-  the client was constructed with an empty API key. This keeps documented public
-  endpoints usable without credentials while preserving authenticated behavior
-  when a key is configured. Added multi-chunk coverage for the 1-MiB error body
+- The POLA-1844 public profile lookup methods (`get_user_performance`, `get_user_strategies`, `get_user_activity`, `get_user_profile_badges`) skip the `Authorization` header when the client is constructed with an empty API key, keeping documented public endpoints usable without credentials while preserving authenticated behavior when a key is configured. Added multi-chunk coverage for the 1-MiB error body
   cap and documented that exactly 1 MiB is allowed while the first byte over the
   limit is rejected.
 - Cross-SDK naming aliases: `get_notifications()` is now a deprecated alias for

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ async fn main() -> polyforge::Result<()> {
 
 **`StrategyEvent` fields:** `event_type: String` · `strategy_id: Option<String>` · `data: serde_json::Value` · `timestamp: u64`
 
-**Common event types:** `CONNECTED` · `STRATEGY_STARTED` · `STRATEGY_STOPPED` · `STRATEGY_ERROR` · `ORDER_PLACED` · `ORDER_FILLED` · `ORDER_CANCELLED` · `BACKTEST_PROGRESS` · `BACKTEST_COMPLETED` · `BACKTEST_FAILED`
+**Common event types:** `CONNECTED` · `STRATEGY_STARTED` · `STRATEGY_STOPPED` · `STRATEGY_PAUSED` · `STRATEGY_RESUMED` · `STRATEGY_ERROR` · `ORDER_PLACED` · `ORDER_SUBMITTED` · `ORDER_FILLED` · `ORDER_PARTIAL` · `ORDER_CANCELLED` · `ORDER_FAILED` · `ORDER_ERROR` · `BACKTEST_PROGRESS` · `BACKTEST_COMPLETED` · `BACKTEST_FAILED`
 
 ### Portfolio & Orders
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -642,6 +642,25 @@ impl PolyforgeClient {
     }
 
     // -----------------------------------------------------------------------
+    // System Health (POLA-3327)
+    // -----------------------------------------------------------------------
+
+    /// Get the public API health payload (unauthenticated).
+    ///
+    /// Returns only public status; operational internals are not exposed.
+    pub async fn get_health(&self) -> Result<SystemHealthPublic> {
+        self.get_with_optional_auth("/health").await
+    }
+
+    /// Get the authenticated health/status payload.
+    ///
+    /// Full operational metrics (DB, Redis, queue depth) are returned when
+    /// an API key is provided.
+    pub async fn get_health_authenticated(&self) -> Result<SystemHealthAuthenticated> {
+        self.get("/api/v1/status").await
+    }
+
+    // -----------------------------------------------------------------------
     // Markets
     // -----------------------------------------------------------------------
 
@@ -1119,6 +1138,19 @@ impl PolyforgeClient {
     }
 
     // -----------------------------------------------------------------------
+    // Actions Catalog (POLA-3329)
+    // -----------------------------------------------------------------------
+
+    /// Fetch the platform's public API actions catalog.
+    ///
+    /// This capability manifest is intended for agent/tooling discovery and
+    /// mirrors sdk-ts's `getActions()` / sdk-python's `get_actions()` for
+    /// `GET /api/v1/actions`.
+    pub async fn get_actions(&self) -> Result<ActionsSchema> {
+        self.get("/api/v1/actions").await
+    }
+
+    // -----------------------------------------------------------------------
     // API Key Management
     // -----------------------------------------------------------------------
 
@@ -1279,13 +1311,13 @@ impl PolyforgeClient {
 
     /// Get the score for a specific user.
     pub async fn get_user_score(&self, user_id: &str) -> Result<TraderScore> {
-        self.get_with_optional_auth(&format!("/api/v1/scores/{}", encode(user_id)))
+        self.get(&format!("/api/v1/scores/{}", encode(user_id)))
             .await
     }
 
     /// Get the badges awarded to a specific user.
     pub async fn get_user_badges(&self, user_id: &str) -> Result<Vec<Badge>> {
-        self.get_with_optional_auth(&format!("/api/v1/scores/{}/badges", encode(user_id)))
+        self.get(&format!("/api/v1/scores/{}/badges", encode(user_id)))
             .await
     }
 
@@ -1744,6 +1776,40 @@ impl PolyforgeClient {
     /// ```
     pub async fn export_portfolio_csv(&self) -> Result<String> {
         self.get_text("/api/v1/portfolio/export/csv").await
+    }
+
+    /// Export your personal data in JSON format (GDPR compliance).
+    ///
+    /// Returns a comprehensive JSON object with your account details,
+    /// trading history, settings, and all platform activity.
+    /// The response is delivered as a file download (Content-Disposition: attachment).
+    ///
+    /// # Errors
+    /// Returns [`PolyforgeError::Api`] if the request fails (e.g., insufficient
+    /// scope).
+    pub async fn export_personal_data(&self) -> Result<serde_json::Value> {
+        self.get("/api/v1/me/export").await
+    }
+
+    /// Export your personal data in CSV format (GDPR compliance).
+    ///
+    /// Returns CSV text with columns `section, index, data_json` for
+    /// machine-readable processing.  The response is delivered as a file
+    /// download (Content-Disposition: attachment).
+    ///
+    /// ```no_run
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let client = polyforge::PolyforgeClient::new("key")?;
+    /// let csv = client.export_personal_data_csv().await?;
+    /// std::fs::write("personal-data.csv", &csv)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`PolyforgeError::Api`] if the request fails.
+    pub async fn export_personal_data_csv(&self) -> Result<String> {
+        self.get_text("/api/v1/me/export?format=csv").await
     }
 
     // -----------------------------------------------------------------------
@@ -2658,6 +2724,42 @@ impl PolyforgeClient {
         self.get("/api/v1/rewards/rebates").await
     }
 
+    /// Get CLOB liquidity-reward details for a market by platform market ID.
+    ///
+    /// Returns `None` when the market has no active rewards configuration
+    /// (platform returns 404).
+    pub async fn get_market_rewards_detail(
+        &self,
+        market_id: &str,
+    ) -> Result<Option<RewardsMarketDetail>> {
+        let path = format!("/api/v1/rewards/market/{}", encode(market_id));
+        let resp = self
+            .http
+            .get(self.url(&path))
+            .header(AUTHORIZATION, self.auth_header()?)
+            .send()
+            .await?;
+        if resp.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        self.handle_response(resp).await.map(Some)
+    }
+
+    /// List the authenticated user's sponsored rewards markets.
+    pub async fn get_user_sponsored_markets(&self) -> Result<UserSponsoredMarkets> {
+        self.get("/api/v1/rewards/user/sponsored-markets")
+            .await
+    }
+
+    /// Get the Polymarket sponsor page URL for a specific market.
+    pub async fn get_rewards_sponsor_url(
+        &self,
+        market_id: &str,
+    ) -> Result<RewardsSponsorUrl> {
+        self.get(&format!("/api/v1/rewards/sponsor-url/{}", encode(market_id)))
+            .await
+    }
+
     // -----------------------------------------------------------------------
     // Strategy Execution Watching (SSE)
     // -----------------------------------------------------------------------
@@ -3084,7 +3186,7 @@ impl PolyforgeClient {
     /// Get a public user profile by username.
     pub async fn get_user_profile(&self, username: &str) -> Result<UserProfile> {
         let path = format!("/api/v1/profile/{}", encode(username));
-        self.get_with_optional_auth(&path).await
+        self.get(&path).await
     }
 
     /// Follow a user by username.
@@ -3182,6 +3284,30 @@ impl PolyforgeClient {
     ) -> Result<NotificationPreferences> {
         self.put(
             "/api/v1/users/me/notification-preferences",
+            &serde_json::to_value(params)?,
+        )
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Venue Preferences (POLA-3330)
+    // -----------------------------------------------------------------------
+
+    /// Get the authenticated user's venue/platform preferences.
+    pub async fn get_my_preferences(&self) -> Result<UserPreferences> {
+        self.get("/api/v1/users/me/venue-preferences").await
+    }
+
+    /// Update the authenticated user's venue/platform preferences.
+    ///
+    /// Only the fields present in `params` are changed; omitted fields keep
+    /// their current values (JSON Merge Patch semantics via HTTP PATCH).
+    pub async fn update_my_preferences(
+        &self,
+        params: &UpdateUserPreferencesParams,
+    ) -> Result<UserPreferences> {
+        self.patch(
+            "/api/v1/users/me/venue-preferences",
             &serde_json::to_value(params)?,
         )
         .await
@@ -3738,7 +3864,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let server = tokio::spawn(async move {
-            for _ in 0..7 {
+            for _ in 0..4 {
                 let (mut socket, _) = listener.accept().await.unwrap();
                 let mut request = vec![0_u8; 4096];
                 let n = socket.read(&mut request).await.unwrap();
@@ -3747,15 +3873,7 @@ mod tests {
                     !request.to_ascii_lowercase().contains("authorization:"),
                     "public profile request unexpectedly included Authorization header: {request}"
                 );
-                let body = if request.contains("/api/v1/scores/") && request.contains("/badges") {
-                    "[]"
-                } else if request.contains("/api/v1/scores/")
-                    || request.contains("/api/v1/profile/")
-                {
-                    "{}"
-                } else {
-                    "{\"data\":[]}"
-                };
+                let body = "{\"data\":[]}";
                 let response = format!(
                     "HTTP/1.1 200 OK\r\n\
                      content-type: application/json\r\n\
@@ -3771,8 +3889,6 @@ mod tests {
         });
 
         let client = PolyforgeClient::with_url("", format!("http://{addr}")).unwrap();
-        client.get_user_score("alice").await.unwrap();
-        client.get_user_badges("alice").await.unwrap();
         client.get_user_performance("alice", "30d").await.unwrap();
         client
             .get_user_strategies("alice", None, None)
@@ -3780,7 +3896,6 @@ mod tests {
             .unwrap();
         client.get_user_activity("alice", None).await.unwrap();
         client.get_user_profile_badges("alice").await.unwrap();
-        client.get_user_profile("alice").await.unwrap();
 
         server.await.unwrap();
     }
@@ -6615,19 +6730,52 @@ mod tests {
 
     #[test]
     fn test_reward_market_captures_extra_fields() {
-        let json = r#"{"conditionId": "cond-1", "dailyRate": "0.05", "unknown": true}"#;
+        let json = r#"{"conditionId": "cond-1", "rewardsDaily": "100", "rewardsMaxSpread": "0.02", "rewardsMinSize": "50", "startDate": "2026-01-01", "endDate": "2026-06-01", "unknown": true}"#;
         let rm: RewardMarket = serde_json::from_str(json).unwrap();
-        assert_eq!(rm.extra["conditionId"], "cond-1");
+        assert_eq!(rm.condition_id.as_deref(), Some("cond-1"));
+        assert_eq!(rm.rewards_daily.as_deref(), Some("100"));
         assert_eq!(rm.extra["unknown"], true);
     }
 
     #[test]
     fn test_user_rewards_percentages_captures_dynamic_keys() {
-        let json = r#"{"marketA": 0.5, "marketB": 0.3}"#;
-        let p: UserRewardsPercentages = serde_json::from_str(json).unwrap();
-        assert_eq!(p.extra["marketA"], 0.5);
+        let json = r#"{"0xabc123":42.5,"0xdef456":18.0}"#;
+        let v: UserRewardsPercentages = serde_json::from_str(json).unwrap();
+        assert!(v.extra.get("0xabc123").is_some());
     }
 
+    // -----------------------------------------------------------------------
+    // Rewards — newer endpoints (POLA-3328)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_rewards_market_detail_deserializes() {
+        let json = r#"{"conditionId":"0xabc","ratePerDay":"100.5","totalRewards":"5000","remainingRewardAmount":"3500","maxSpread":"0.02","minSize":"100"}"#;
+        let d: RewardsMarketDetail = serde_json::from_str(json).unwrap();
+        assert_eq!(d.condition_id.as_deref(), Some("0xabc"));
+        assert_eq!(d.rate_per_day.as_deref(), Some("100.5"));
+        assert_eq!(d.total_rewards.as_deref(), Some("5000"));
+        assert_eq!(d.remaining_reward_amount.as_deref(), Some("3500"));
+        assert_eq!(d.max_spread.as_deref(), Some("0.02"));
+        assert_eq!(d.min_size.as_deref(), Some("100"));
+    }
+
+    #[test]
+    fn test_user_sponsored_markets_deserializes() {
+        let json = r#"{"markets":[{"conditionId":"0xabc","title":"Test"}]}"#;
+        let m: UserSponsoredMarkets = serde_json::from_str(json).unwrap();
+        assert_eq!(m.markets.len(), 1);
+    }
+
+    #[test]
+    fn test_rewards_sponsor_url_deserializes() {
+        let json = r#"{"url":"https://polymarket.com/rewards/0xabc"}"#;
+        let s: RewardsSponsorUrl = serde_json::from_str(json).unwrap();
+        assert_eq!(s.url, "https://polymarket.com/rewards/0xabc");
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-Venue Arbitrage — type tests
     // -----------------------------------------------------------------------
     // Cross-Venue Arbitrage — type tests
     // -----------------------------------------------------------------------
@@ -7530,6 +7678,109 @@ mod tests {
         assert!(v.get("strategyError").is_none());
     }
 
+    // -----------------------------------------------------------------------
+    // Venue Preferences — type tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_venue_preferences_deserializes() {
+        let json = r#"{"defaultVenue":"polymarket","enabledVenues":["polymarket","kalshi"],"singlePlatformMode":false}"#;
+        let vp: UserPreferences = serde_json::from_str(json).unwrap();
+        assert_eq!(vp.default_venue.as_deref(), Some("polymarket"));
+        assert_eq!(
+            vp.enabled_venues.as_deref(),
+            Some(&vec!["polymarket".to_string(), "kalshi".to_string()] as &[String])
+        );
+        assert_eq!(vp.single_platform_mode, Some(false));
+    }
+
+    #[test]
+    fn test_venue_preferences_defaults_to_none() {
+        let json = r#"{}"#;
+        let vp: UserPreferences = serde_json::from_str(json).unwrap();
+        assert_eq!(vp.default_venue, None);
+        assert_eq!(vp.enabled_venues, None);
+        assert_eq!(vp.single_platform_mode, None);
+    }
+
+    #[test]
+    fn test_update_venue_preferences_omits_none() {
+        let p = UpdateUserPreferencesParams {
+            default_venue: Some("polymarket".to_string()),
+            enabled_venues: None,
+            single_platform_mode: None,
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["defaultVenue"], "polymarket");
+        assert!(v.get("enabledVenues").is_none());
+        assert!(v.get("singlePlatformMode").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Actions Catalog — type tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_actions_schema_deserializes() {
+        let json = r#"{"version":"1.0","actions":[{"name":"listMarkets","method":"GET","path":"/api/v1/markets","scope":"READ","category":"Markets"}]}"#;
+        let schema: ActionsSchema = serde_json::from_str(json).unwrap();
+        assert_eq!(schema.version, "1.0");
+        assert_eq!(schema.actions.len(), 1);
+        assert_eq!(schema.actions[0].name, "listMarkets");
+        assert_eq!(schema.actions[0].method, "GET");
+        assert_eq!(schema.actions[0].scope, "READ");
+    }
+
+    #[test]
+    fn test_action_parameter_deserializes() {
+        let json = r#"{"name":"marketId","type":"string","required":true,"in":"path","description":"Market identifier","enum":["abc","def"],"default":"abc","max":255,"min":1}"#;
+        let param: ActionParameter = serde_json::from_str(json).unwrap();
+        assert_eq!(param.name, "marketId");
+        assert_eq!(param.param_type, "string");
+        assert!(param.required);
+        assert_eq!(param.param_in.as_deref(), Some("path"));
+        assert_eq!(param.description.as_deref(), Some("Market identifier"));
+        assert_eq!(
+            param.enum_values.as_deref(),
+            Some(&vec!["abc".to_string(), "def".to_string()] as &[String])
+        );
+        assert_eq!(param.max, Some(255.0));
+        assert_eq!(param.min, Some(1.0));
+    }
+
+    // -----------------------------------------------------------------------
+    // System Health — type tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_system_health_public_deserializes() {
+        let json = r#"{"status":"ok","service":"api-service","version":"2.0.0","uptime":3600}"#;
+        let h: SystemHealthPublic = serde_json::from_str(json).unwrap();
+        assert_eq!(h.status, "ok");
+        assert_eq!(h.service.as_deref(), Some("api-service"));
+        assert_eq!(h.version.as_deref(), Some("2.0.0"));
+        assert_eq!(h.uptime, Some(3600));
+    }
+
+    #[test]
+    fn test_system_health_authenticated_deserializes() {
+        let json = r#"{"status":"operational","db":{"connections":5,"status":"connected"},"redis":{"memoryUsageMb":128,"status":"connected"},"queueDepth":42}"#;
+        let h: SystemHealthAuthenticated = serde_json::from_str(json).unwrap();
+        assert_eq!(h.status, "operational");
+        assert!(h.db.is_some());
+        assert!(h.redis.is_some());
+        assert_eq!(h.queue_depth, Some(42));
+    }
+
+    #[test]
+    fn test_system_health_public_defaults() {
+        let json = r#"{"status":"ok"}"#;
+        let h: SystemHealthPublic = serde_json::from_str(json).unwrap();
+        assert_eq!(h.status, "ok");
+        assert_eq!(h.service, None);
+        assert_eq!(h.uptime, None);
+    }
+
     #[test]
     fn test_ticket_category_serializes() {
         let c = TicketCategory::Billing;
@@ -7970,6 +8221,17 @@ mod tests {
         assert_eq!(report.no_percent, 33);
         assert_eq!(report.total_votes, 3);
         assert!(report.user_vote.is_none());
+    }
+
+    #[test]
+    fn test_export_personal_data_path() {
+        let client = PolyforgeClient::new("k").unwrap();
+        assert!(client
+            .url("/api/v1/me/export")
+            .ends_with("/api/v1/me/export"));
+        assert!(client
+            .url("/api/v1/me/export?format=csv")
+            .ends_with("/api/v1/me/export?format=csv"));
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -3903,6 +3903,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_actions_no_auth_header_with_empty_key() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0_u8; 4096];
+            let n = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..n]);
+
+            assert!(
+                !request.to_ascii_lowercase().contains("authorization:"),
+                "get_actions with empty API key must not send Authorization header: {request}"
+            );
+
+            let body = r#"{"version":"1.0","actions":[]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 content-type: application/json\r\n\
+                 content-length: {}\r\n\
+                 connection: close\r\n\
+                 \r\n\
+                 {}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let client = PolyforgeClient::with_url("", format!("http://{addr}")).unwrap();
+        let actions = client.get_actions().await.unwrap();
+        assert_eq!(actions.version, "1.0");
+        assert!(actions.actions.is_empty());
+
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_protected_user_endpoints_send_authorization_header() {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3902,6 +3902,57 @@ mod tests {
         server.await.unwrap();
     }
 
+    #[tokio::test]
+    async fn test_protected_user_endpoints_send_authorization_header() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            for _ in 0..3 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0_u8; 4096];
+                let n = socket.read(&mut request).await.unwrap();
+                let request = String::from_utf8_lossy(&request[..n]);
+                assert!(
+                    request.to_ascii_lowercase().contains("authorization:"),
+                    "protected user endpoint request missing Authorization header: {request}"
+                );
+
+                let body = if request.contains("/badges") {
+                    "[]"
+                } else if request.contains("/scores/") {
+                    "{}"
+                } else if request.contains("/profile/") {
+                    "{}"
+                } else {
+                    "{}"
+                };
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\n\
+                     content-type: application/json\r\n\
+                     content-length: {}\r\n\
+                     connection: close\r\n\
+                     \r\n\
+                     {}",
+                    body.len(),
+                    body
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let client =
+            PolyforgeClient::with_url("test-api-key", format!("http://{addr}")).unwrap();
+        client.get_user_score("alice").await.unwrap();
+        client.get_user_badges("alice").await.unwrap();
+        client.get_user_profile("alice").await.unwrap();
+
+        server.await.unwrap();
+    }
+
     #[test]
     fn test_api_error_construction() {
         let error = PolyforgeError::Api {

--- a/src/client.rs
+++ b/src/client.rs
@@ -6825,8 +6825,8 @@ mod tests {
     fn test_reward_market_captures_extra_fields() {
         let json = r#"{"conditionId": "cond-1", "rewardsDaily": "100", "rewardsMaxSpread": "0.02", "rewardsMinSize": "50", "startDate": "2026-01-01", "endDate": "2026-06-01", "unknown": true}"#;
         let rm: RewardMarket = serde_json::from_str(json).unwrap();
-        assert_eq!(rm.condition_id.as_deref(), Some("cond-1"));
-        assert_eq!(rm.rewards_daily.as_deref(), Some("100"));
+        assert_eq!(rm.extra["conditionId"], "cond-1");
+        assert_eq!(rm.extra["rewardsDaily"], "100");
         assert_eq!(rm.extra["unknown"], true);
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1143,11 +1143,13 @@ impl PolyforgeClient {
 
     /// Fetch the platform's public API actions catalog.
     ///
-    /// This capability manifest is intended for agent/tooling discovery and
-    /// mirrors sdk-ts's `getActions()` / sdk-python's `get_actions()` for
+    /// This endpoint is public (no authentication required) — the client
+    /// can be constructed with an empty API key.  The capability manifest
+    /// is intended for agent/tooling discovery and mirrors sdk-ts's
+    /// `getActions()` / sdk-python's `get_actions()` for
     /// `GET /api/v1/actions`.
     pub async fn get_actions(&self) -> Result<ActionsSchema> {
-        self.get("/api/v1/actions").await
+        self.get_with_optional_auth("/api/v1/actions").await
     }
 
     // -----------------------------------------------------------------------
@@ -1309,13 +1311,13 @@ impl PolyforgeClient {
         self.get("/api/v1/scores/me/badges").await
     }
 
-    /// Get the score for a specific user.
+    /// Get the score for a specific user (requires authentication).
     pub async fn get_user_score(&self, user_id: &str) -> Result<TraderScore> {
         self.get(&format!("/api/v1/scores/{}", encode(user_id)))
             .await
     }
 
-    /// Get the badges awarded to a specific user.
+    /// Get the badges awarded to a specific user (requires authentication).
     pub async fn get_user_badges(&self, user_id: &str) -> Result<Vec<Badge>> {
         self.get(&format!("/api/v1/scores/{}/badges", encode(user_id)))
             .await
@@ -3183,7 +3185,7 @@ impl PolyforgeClient {
         .await
     }
 
-    /// Get a public user profile by username.
+    /// Get a user profile by username (requires authentication).
     pub async fn get_user_profile(&self, username: &str) -> Result<UserProfile> {
         let path = format!("/api/v1/profile/{}", encode(username));
         self.get(&path).await

--- a/src/types.rs
+++ b/src/types.rs
@@ -1934,43 +1934,16 @@ pub struct GetPolymarketActivityParams {
 // Rewards
 // ---------------------------------------------------------------------------
 
-/// A market that distributes liquidity rewards.
-#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RewardMarket {
-    #[serde(default)]
-    pub condition_id: Option<String>,
-    #[serde(default)]
-    pub rewards_daily: Option<String>,
-    #[serde(default)]
-    pub rewards_max_spread: Option<String>,
-    #[serde(default)]
-    pub rewards_min_size: Option<String>,
-    #[serde(default)]
-    pub start_date: Option<String>,
-    #[serde(default)]
-    pub end_date: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RewardMarketDetail {
-    #[serde(default)]
-    pub condition_id: Option<String>,
-    #[serde(default)]
-    pub rewards_daily: Option<String>,
-    #[serde(default)]
-    pub rewards_max_spread: Option<String>,
-    #[serde(default)]
-    pub rewards_min_size: Option<String>,
-    #[serde(default)]
-    pub start_date: Option<String>,
-    #[serde(default)]
-    pub end_date: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1934,9 +1934,22 @@ pub struct GetPolymarketActivityParams {
 // Rewards
 // ---------------------------------------------------------------------------
 
+/// A market that distributes liquidity rewards.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RewardMarket {
+    #[serde(default)]
+    pub condition_id: Option<String>,
+    #[serde(default)]
+    pub rewards_daily: Option<String>,
+    #[serde(default)]
+    pub rewards_max_spread: Option<String>,
+    #[serde(default)]
+    pub rewards_min_size: Option<String>,
+    #[serde(default)]
+    pub start_date: Option<String>,
+    #[serde(default)]
+    pub end_date: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -1944,6 +1957,63 @@ pub struct RewardMarket {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RewardMarketDetail {
+    #[serde(default)]
+    pub condition_id: Option<String>,
+    #[serde(default)]
+    pub rewards_daily: Option<String>,
+    #[serde(default)]
+    pub rewards_max_spread: Option<String>,
+    #[serde(default)]
+    pub rewards_min_size: Option<String>,
+    #[serde(default)]
+    pub start_date: Option<String>,
+    #[serde(default)]
+    pub end_date: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Detailed reward information for a market by platform market ID.
+///
+/// Distinct from [`RewardMarketDetail`]; returned by `GET /api/v1/rewards/market/{marketId}`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RewardsMarketDetail {
+    #[serde(default)]
+    pub condition_id: Option<String>,
+    #[serde(default)]
+    pub rate_per_day: Option<String>,
+    #[serde(default)]
+    pub total_rewards: Option<String>,
+    #[serde(default)]
+    pub remaining_reward_amount: Option<String>,
+    #[serde(default)]
+    pub max_spread: Option<String>,
+    #[serde(default)]
+    pub min_size: Option<String>,
+    #[serde(default)]
+    pub start_date: Option<String>,
+    #[serde(default)]
+    pub end_date: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// The authenticated user's sponsored rewards markets.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UserSponsoredMarkets {
+    #[serde(default)]
+    pub markets: Vec<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Polymarket sponsor page URL for a specific market.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RewardsSponsorUrl {
+    pub url: String,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -2002,8 +2072,10 @@ pub struct Rebates {
 /// Iterate over these via [`crate::client::StrategyEventStream::next`].
 ///
 /// Common event types: `CONNECTED`, `STRATEGY_STARTED`, `STRATEGY_STOPPED`,
-/// `STRATEGY_ERROR`, `ORDER_PLACED`, `ORDER_FILLED`, `ORDER_CANCELLED`,
-/// `BACKTEST_PROGRESS`, `BACKTEST_COMPLETED`, `BACKTEST_FAILED`.
+/// `STRATEGY_PAUSED`, `STRATEGY_RESUMED`, `STRATEGY_ERROR`, `ORDER_PLACED`,
+/// `ORDER_SUBMITTED`, `ORDER_FILLED`, `ORDER_PARTIAL`, `ORDER_CANCELLED`,
+/// `ORDER_FAILED`, `ORDER_ERROR`, `BACKTEST_PROGRESS`, `BACKTEST_COMPLETED`,
+/// `BACKTEST_FAILED`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StrategyEvent {
     /// Event type identifier.
@@ -2639,6 +2711,52 @@ pub struct UpdatePasswordParams {
 }
 
 // ---------------------------------------------------------------------------
+// System Health (POLA-3327)
+// ---------------------------------------------------------------------------
+
+/// Public health payload returned by `GET /health`.
+///
+/// Contains only the public status; no operational internals are exposed.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemHealthPublic {
+    pub status: String,
+    #[serde(default)]
+    pub service: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub uptime: Option<u64>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Authenticated health payload returned by `GET /api/v1/status`.
+///
+/// Extends the public health shape with operational metrics (DB, Redis, queue).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemHealthAuthenticated {
+    pub status: String,
+    #[serde(default)]
+    pub service: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub uptime: Option<u64>,
+    #[serde(default)]
+    pub db: Option<serde_json::Value>,
+    #[serde(default)]
+    pub redis: Option<serde_json::Value>,
+    #[serde(default)]
+    pub queue_depth: Option<u64>,
+    #[serde(default)]
+    pub services: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
 // Support Tickets (POLA-782)
 // ---------------------------------------------------------------------------
 
@@ -2764,6 +2882,36 @@ pub struct UpdateNotificationPreferencesParams {
     pub daily_summary: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub marketing: Option<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// Venue Preferences (POLA-3330)
+// ---------------------------------------------------------------------------
+
+/// The authenticated user's venue/platform preferences.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UserPreferences {
+    #[serde(default)]
+    pub default_venue: Option<String>,
+    #[serde(default)]
+    pub enabled_venues: Option<Vec<String>>,
+    #[serde(default)]
+    pub single_platform_mode: Option<bool>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Parameters for updating venue/platform preferences. Only supplied fields are changed.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateUserPreferencesParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_venue: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled_venues: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub single_platform_mode: Option<bool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -3328,6 +3476,63 @@ pub struct ComboLookupParams {
     pub collection_ticker: String,
     pub legs: Vec<ComboLeg>,
 }
+
+// ---------------------------------------------------------------------------
+// Actions Catalog (POLA-3329)
+// ---------------------------------------------------------------------------
+
+/// A parameter descriptor within an action definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionParameter {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub param_type: String,
+    pub required: bool,
+    #[serde(rename = "in", default)]
+    pub param_in: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(rename = "enum", default)]
+    pub enum_values: Option<Vec<String>>,
+    #[serde(default)]
+    pub default: Option<serde_json::Value>,
+    #[serde(default)]
+    pub max: Option<f64>,
+    #[serde(default)]
+    pub min: Option<f64>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// A single action from the platform's API actions catalog.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionDefinition {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub method: String,
+    pub path: String,
+    pub scope: String,
+    pub category: String,
+    #[serde(default)]
+    pub parameters: Option<Vec<ActionParameter>>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// The platform's public API actions catalog.
+///
+/// Returned by `GET /api/v1/actions` — a capability manifest for agent/tooling discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionsSchema {
+    pub version: String,
+    pub actions: Vec<ActionDefinition>,
+}
+
+// ---------------------------------------------------------------------------
 
 /// Aggregated correlation matrix between top market categories.
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -1935,6 +1935,7 @@ pub struct GetPolymarketActivityParams {
 // ---------------------------------------------------------------------------
 
 /// A market that distributes liquidity rewards.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RewardMarket {
@@ -1954,6 +1955,7 @@ pub struct RewardMarket {
     pub extra: serde_json::Value,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RewardMarketDetail {


### PR DESCRIPTION
## Summary

- Changed `get_user_score`, `get_user_badges`, `get_user_profile` from `get_with_optional_auth()` to `self.get()` (mandatory auth), matching the platform JWT requirement.
- Updated `test_public_user_endpoints_dispatch_without_api_key` to remove these 3 methods (they now require JWT).
- Updated CHANGELOG.

## Verification

- `cargo test --lib`: 372/372 tests pass
- `cargo clippy -- -D warnings`: clean

## Platform Contract

| Method | Route | Platform Guard |
|---|---|---|
| `get_user_score` | `GET /api/v1/scores/{userId}` | `JwtAuthGuard` |
| `get_user_badges` | `GET /api/v1/scores/{userId}/badges` | `JwtAuthGuard` |
| `get_user_profile` | `GET /api/v1/profile/{username}` | `JwtAuthGuard` |