### PR TITLE
fix: update report_strategy doc — replace HARMFUL with INAPPROPRIATE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- **report_strategy doc** — updated `report_strategy` doc comment to reference `"INAPPROPRIATE"` instead of `"HARMFUL"` to match the platform's current report reason values. (closes #227)
 - **Arbitrage docstrings** — updated cross-venue arb docstrings to reflect backend hardening (POLA-1911, POLA-1958):
   - `Idempotency-Key` is now **required** on `execute_arbitrage` and `close_arbitrage_position` (8–128 characters, validated client-side).
   - Rate limit of **5 req/min/user** on execute and close endpoints; exceeding it returns HTTP 429.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1216,7 +1216,7 @@ impl PolyforgeClient {
 
     /// Report a strategy for violating guidelines.
     ///
-    /// `reason` should be one of `"SPAM"`, `"MISLEADING"`, `"HARMFUL"`, `"OTHER"`.
+    /// `reason` should be one of `"SPAM"`, `"MISLEADING"`, `"INAPPROPRIATE"`, `"OTHER"`.
     pub async fn report_strategy(
         &self,
         id: &str,


### PR DESCRIPTION
## Summary
- Changed report_strategy doc comment: HARMFUL -> INAPPROPRIATE to match current platform expectations (#227)

## Test Plan
- All 372 tests pass (0 failures)
- Single-line doc change, no behavioral impact