### PR TITLE
feat: 3 newer Rewards endpoints + GDPR export + health/actions/preferences (POLA-3818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@
 - **Disable automatic redirects** — set `redirect(Policy::none())` on the HTTP client to prevent the Bearer token from being forwarded to third-party hosts via 3xx redirects (closes #25)
 - **Webhook secret skip_serializing** — added `#[serde(skip_serializing)]` to `Webhook.secret` field to prevent the HMAC signing secret from leaking via `serde_json::to_string()` or any serialization path; regression of #8 where only `Debug` was fixed but `Serialize` was missed (closes #43)
 
+- **3 newer Rewards endpoints (POLA-3683)** — 3 new `PolyforgeClient` methods closing the gap to the platform's `/api/v1/rewards/*` surface and bringing parity with `polyforge-sdk-ts`:
+  - `get_market_rewards_detail(market_id)` → `GET /api/v1/rewards/market/{marketId}` → `Option<RewardsMarketDetail>` — returns CLOB liquidity-reward configuration for a platform market (returns `None` on 404 when the market has no active rewards).
+  - `get_user_sponsored_markets()` → `GET /api/v1/rewards/user/sponsored-markets` → `UserSponsoredMarkets` — list the authenticated user's sponsored-rewards markets.
+  - `get_rewards_sponsor_url(market_id)` → `GET /api/v1/rewards/sponsor-url/{marketId}` → `RewardsSponsorUrl` — get the Polymarket sponsor page URL for a specific market.
+  - New types: `RewardsMarketDetail`, `UserSponsoredMarkets`, `RewardsSponsorUrl`. All use `#[serde(flatten)] extra: serde_json::Value` for forward-compatibility.
+
 ### Fixed
 - **Trading writes** — automatically attach a fresh `Idempotency-Key` header to order, bulk order, liquidity, position, smart-order, and conditional-order mutations so platform idempotency validation no longer rejects Rust SDK writes with `MISSING_IDEMPOTENCY_KEY`. (closes #197)
 - **`RewardMarket.extra` / `RewardMarketDetail.extra` backward compatibility** — custom `Deserialize` implementations now preserve ALL response fields (including named ones) inside `extra`, so downstream code that reads `extra["conditionId"]` or other previously-dynamic keys continues to work after the keys were promoted to first-class struct fields. 1 new test and 6 new assertions verify the backward-compatible shape.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,29 @@ client.get_market_sentiment("market-id").await?
 client.provide_liquidity(&ProvideLiquidityParams { token_id, spread, size }).await?
 ```
 
+### Rewards
+
+| Method | Description |
+|--------|-------------|
+| `list_rewards_markets()` | List all markets with active liquidity rewards → `Vec<RewardMarket>` |
+| `get_rewards_for_market(condition_id)` | Get reward details for a Polymarket market by condition ID |
+| `get_user_rewards()` | Get the authenticated user's rewards |
+| `get_user_rewards_total()` | Get the authenticated user's total accumulated rewards |
+| `get_user_rewards_percentages()` | Get the authenticated user's reward percentages |
+| `get_user_rewards_per_market()` | Get the authenticated user's rewards broken down by market |
+| `get_rebates()` | Get the authenticated user's trading fee rebates |
+| `get_market_rewards_detail(market_id)` | Get CLOB liquidity-reward config for a platform market by ID; returns `None` on 404 |
+| `get_user_sponsored_markets()` | List the authenticated user's sponsored rewards markets |
+| `get_rewards_sponsor_url(market_id)` | Get the Polymarket sponsor page URL for a market |
+
+```rust
+client.list_rewards_markets().await?;
+client.get_rewards_for_market("condition-id").await?;
+client.get_user_rewards().await?;
+client.get_user_sponsored_markets().await?;
+client.get_rewards_sponsor_url("market-id").await?;
+```
+
 ### Sports
 
 | Method | Description |


### PR DESCRIPTION
## Summary

Adds 6 new `PolyforgeClient` methods and 10 new types, closing gaps to the platform API surface:

### 3 Newer Rewards Endpoints (POLA-3683 / POLA-3818)
- `get_market_rewards_detail(market_id)` → `GET /api/v1/rewards/market/{marketId}` → `Option<RewardsMarketDetail>` — returns `None` on 404
- `get_user_sponsored_markets()` → `GET /api/v1/rewards/user/sponsored-markets` → `UserSponsoredMarkets`
- `get_rewards_sponsor_url(market_id)` → `GET /api/v1/rewards/sponsor-url/{marketId}` → `RewardsSponsorUrl`

### GDPR Personal Data Export
- `export_personal_data()` → `GET /api/v1/me/export` → JSON
- `export_personal_data_csv()` → `GET /api/v1/me/export?format=csv` → String

### System Health
- `get_health()` → `GET /health` → `SystemHealthPublic` (unauthenticated)
- `get_health_authenticated()` → `GET /api/v1/status` → `SystemHealthAuthenticated`

### Actions Catalog
- `get_actions()` → `GET /api/v1/actions` → `ActionsSchema`

### Venue Preferences
- `get_my_preferences()` → `GET /api/v1/users/me/venue-preferences` → `UserPreferences`
- `update_my_preferences(params)` → `PATCH /api/v1/users/me/venue-preferences` → `UserPreferences`

### Auth Fixes
- `get_user_score`, `get_user_badges`, `get_user_profile` now use required auth (`self.get()`) instead of optional auth, matching platform contract.

## Test Plan
- [x] 372 unit tests passing (incl. 3 new deserialization tests for RewardsMarketDetail, UserSponsoredMarkets, RewardsSponsorUrl)
- [x] 5 doc-tests passing
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build` clean

## New Types
`RewardsMarketDetail`, `UserSponsoredMarkets`, `RewardsSponsorUrl`, `SystemHealthPublic`, `SystemHealthAuthenticated`, `UserPreferences`, `UpdateUserPreferencesParams`, `ActionDefinition`, `ActionParameter`, `ActionsSchema`