### PR TITLE
docs: update arb close/sweep semantics (POLA-1958)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+- **Arbitrage docstrings** — updated cross-venue arb docstrings to reflect backend hardening (POLA-1911, POLA-1958):
+  - `Idempotency-Key` is now **required** on `execute_arbitrage` and `close_arbitrage_position` (8–128 characters, validated client-side).
+  - Rate limit of **5 req/min/user** on execute and close endpoints; exceeding it returns HTTP 429.
+  - `match_id` is validated as a UUID by both the SDK and the backend; non-UUID input returns HTTP 400.
+  - Sweep semantics documented verbatim from the backend: GTC orders at 0.001 SELL / 0.999 BUY behave as a market-equivalent sweep, not a resting limit order. Slippage is bounded only by venue depth at call time.
+  - README arbitrage section expanded with a complete execute-and-close code example showing `Idempotency-Key` usage.
+  - `idempotency_key_header()` validation tightened from non-empty to 8–128 characters.
+
 ### Added
 - **Sports markets API** — 9 new `PolyforgeClient` methods wrapping the `/api/v1/sports/*` endpoints (POLA-1841):
   - `list_sports_categories()` → typed `Vec<SportsCategory>`

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> polyforge::Result<()> {
-    let client = PolyforgeClient::new("your-api-key");
+    let client = PolyforgeClient::new("your-api-key")?;
 
     // Execute an arbitrage trade
     let idempotency_key = Uuid::new_v4().to_string();
@@ -158,14 +158,15 @@ async fn main() -> polyforge::Result<()> {
             &idempotency_key,
         )
         .await?;
-    println!("Opened position: {}", result.arb_position_id);
+    println!("Opened position: {:?}", result.arb_position_id);
 
     // Later: sweep-close the position
     let close_key = Uuid::new_v4().to_string();
+    let pos_id = result.arb_position_id.as_deref().unwrap_or_default();
     let close_result = client
-        .close_arbitrage_position(&result.arb_position_id, &close_key)
+        .close_arbitrage_position(pos_id, &close_key)
         .await?;
-    println!("Close status: {}", close_result.status);
+    println!("Close status: {:?}", close_result.status);
 
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -131,6 +131,46 @@ liquidity, position, smart-order, and conditional-order mutations.
 
 ### Arbitrage
 
+Cross-venue arbitrage between Polymarket and Kalshi.  Key points:
+
+- **Sweep-close only** — arbitrage positions are always closed in full; partial closes are not supported.
+- **Idempotency-Key required** — `execute_arbitrage` and `close_arbitrage_position` both require a caller-supplied idempotency key (8–128 characters).  The SDK sends it as the `Idempotency-Key` header and the backend enforces at-most-once semantics per key.
+- **Rate limit** — the backend enforces 5 req/min/user on execute and close; exceeding it returns HTTP 429.
+- **UUID match_id** — `match_id` must be a valid RFC 4122 UUID; non-UUID input is rejected with HTTP 400.
+
+```rust
+use polyforge::{PolyforgeClient, ExecuteArbitrageParams};
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> polyforge::Result<()> {
+    let client = PolyforgeClient::new("your-api-key");
+
+    // Execute an arbitrage trade
+    let idempotency_key = Uuid::new_v4().to_string();
+    let result = client
+        .execute_arbitrage(
+            &ExecuteArbitrageParams {
+                match_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+                size: 100,
+                max_slippage_pct: Some(0.5),
+            },
+            &idempotency_key,
+        )
+        .await?;
+    println!("Opened position: {}", result.arb_position_id);
+
+    // Later: sweep-close the position
+    let close_key = Uuid::new_v4().to_string();
+    let close_result = client
+        .close_arbitrage_position(&result.arb_position_id, &close_key)
+        .await?;
+    println!("Close status: {}", close_result.status);
+
+    Ok(())
+}
+```
+
 | Method | Description |
 |--------|-------------|
 | `list_arbitrage_opportunities(min_spread)` | List cross-venue Polymarket/Kalshi opportunities |
@@ -138,7 +178,7 @@ liquidity, position, smart-order, and conditional-order mutations.
 | `execute_arbitrage(params, idempotency_key)` | Execute a real cross-venue arbitrage trade; sends `Idempotency-Key` and validates UUID `match_id`, integer `size` 1..=10000, and optional slippage 0..=5 |
 | `list_arbitrage_positions(status, limit, offset)` | List arbitrage positions with typed `ArbPositionStatus` and `limit` 1..=100 |
 | `get_arbitrage_position(position_id)` | Fetch one arbitrage position |
-| `close_arbitrage_position(position_id, idempotency_key)` | Close an open arbitrage position with real reverse orders and `Idempotency-Key` |
+| `close_arbitrage_position(position_id, idempotency_key)` | Sweep-close an open arbitrage position with real reverse orders and `Idempotency-Key` |
 | `get_arbitrage_risk_dashboard()` | Get aggregate arbitrage exposure and P&L |
 | `get_arbitrage_settlement_risks()` | List settlement-date and resolution-criteria risks |
 | `refresh_arbitrage_pnl()` | Recompute unrealized arbitrage P&L |

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Cross-venue arbitrage between Polymarket and Kalshi.  Key points:
 - **UUID match_id** — `match_id` must be a valid RFC 4122 UUID; non-UUID input is rejected with HTTP 400.
 
 ```rust
-use polyforge::{PolyforgeClient, ExecuteArbitrageParams};
+use polyforge::{PolyforgeClient, PolyforgeError, ExecuteArbitrageParams};
 use uuid::Uuid;
 
 #[tokio::main]
@@ -161,8 +161,12 @@ async fn main() -> polyforge::Result<()> {
     println!("Opened position: {:?}", result.arb_position_id);
 
     // Later: sweep-close the position
+    let pos_id = result.arb_position_id.as_deref().ok_or_else(|| {
+        PolyforgeError::Validation(
+            "execute_arbitrage response missing arb_position_id".into(),
+        )
+    })?;
     let close_key = Uuid::new_v4().to_string();
-    let pos_id = result.arb_position_id.as_deref().unwrap_or_default();
     let close_result = client
         .close_arbitrage_position(pos_id, &close_key)
         .await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -396,10 +396,11 @@ impl PolyforgeClient {
     }
 
     fn idempotency_key_header(idempotency_key: &str) -> Result<HeaderValue> {
-        if idempotency_key.trim().is_empty() {
-            return Err(PolyforgeError::Validation(
-                "idempotency_key must not be empty".into(),
-            ));
+        if idempotency_key.len() < 8 || idempotency_key.len() > 128 {
+            return Err(PolyforgeError::Validation(format!(
+                "idempotency_key must be 8–128 characters, got {}",
+                idempotency_key.len()
+            )));
         }
         HeaderValue::from_str(idempotency_key).map_err(|_| {
             PolyforgeError::Validation(
@@ -1707,7 +1708,25 @@ impl PolyforgeClient {
             .await
     }
 
-    /// Close an open position (sell all shares at market price).
+    /// Close an open prediction-market position (partial or sweep).
+    ///
+    /// When `params.size` is `None` (the default), this is a **sweep** — the
+    /// entire position is sold at market price via a market sell order.  When
+    /// `size` is set to a number-string like `"100"`, only that portion is
+    /// closed (partial close) and the remainder of the position stays open.
+    ///
+    /// # Sweep semantics
+    ///
+    /// GTC orders are priced at `0.001` SELL / `0.999` BUY and behave as a
+    /// **market-equivalent sweep, not a resting limit order**.  Slippage is
+    /// bounded only by venue depth at call time, not by the on-paper price.
+    /// The fill price is whatever the order book offers at the time of
+    /// execution.
+    ///
+    /// **For cross-venue arbitrage positions**, use
+    /// [`close_arbitrage_position`](Self::close_arbitrage_position) instead —
+    /// arbitrage closes are always full sweeps that place reversing market
+    /// orders on both venues simultaneously; partial closes are not supported.
     ///
     /// The SDK automatically sends an `Idempotency-Key` header required by the
     /// platform for trading writes.
@@ -3020,13 +3039,29 @@ impl PolyforgeClient {
     /// Execute a cross-venue arbitrage trade — places **real** offsetting
     /// orders on Polymarket and Kalshi for a matched market pair.
     ///
-    /// `idempotency_key` is sent as the `Idempotency-Key` header required by
-    /// the backend for this real-order endpoint; reuse the same key for safe
-    /// caller-managed retries of the same intended execution.
+    /// Opens a new [`ArbPosition`] that starts in `OPEN` state.  The position
+    /// is composed of two legs (buy on one venue, sell on the other).  To exit
+    /// the position later, call
+    /// [`close_arbitrage_position`](Self::close_arbitrage_position) which
+    /// performs a **full sweep-close** by placing reversing market orders on
+    /// both venues.  There is no partial-close for arb positions — the only
+    /// exit path is a complete sweep.
+    ///
+    /// `idempotency_key` is sent as the `Idempotency-Key` header and is
+    /// **required** by the backend for this endpoint.  The key must be 8–128
+    /// characters.  Reuse the same key for safe caller-managed retries of the
+    /// same intended execution; the backend guarantees at-most-once semantics
+    /// per key.
+    ///
+    /// `match_id` must be a valid UUID (RFC 4122).  The backend validates
+    /// this server-side and **returns HTTP 400** for non-UUID input.
     ///
     /// `size` must be in `1..=10000` USDC; `max_slippage_pct`, if set, must be
     /// in `0..=5`. Both are validated client-side before any order is sent.
     /// Server defaults `max_slippage_pct` to 0.5 when omitted.
+    ///
+    /// The backend enforces a rate limit of **5 requests per minute per user**
+    /// on this endpoint; exceeding it returns **HTTP 429**.
     ///
     /// Surfaces backend error codes verbatim (`VENUES_NOT_CONNECTED`,
     /// `MATCH_NOT_FOUND`, `COMPARISON_UNAVAILABLE`, `SPREAD_TOO_LOW`,
@@ -3094,12 +3129,30 @@ impl PolyforgeClient {
         self.get(&path).await
     }
 
-    /// Close an open arbitrage position — places **real** reverse orders on
-    /// both venues.
+    /// Sweep-close an open cross-venue arbitrage position — places **real**
+    /// reversing market orders on **both venues** (Polymarket and Kalshi) to
+    /// close the **entire** position at the best available market prices.
     ///
-    /// `idempotency_key` is sent as the `Idempotency-Key` header required by
-    /// the backend for this real-order endpoint; reuse the same key for safe
-    /// caller-managed retries of the same intended close.
+    /// This is always a full sweep — there is no partial-close concept for
+    /// arbitrage positions.  Unlike [`close_position`](Self::close_position),
+    /// which supports partial closes for regular prediction-market positions,
+    /// this endpoint always reverses both legs in full.
+    ///
+    /// The backend transitions the position through `CLOSING` → `CLOSED` (or
+    /// `FAILED` if a reverse order cannot be placed on one or both venues).
+    /// On success the returned [`ArbCloseResponse`] carries the terminal
+    /// `CLOSED` status.  Once closed, realised P&L is available on the
+    /// full [`ArbPosition`] record fetched via
+    /// [`get_arbitrage_position`](Self::get_arbitrage_position).
+    ///
+    /// `idempotency_key` is sent as the `Idempotency-Key` header and is
+    /// **required** by the backend for this endpoint.  The key must be 8–128
+    /// characters.  Reuse the same key for safe caller-managed retries of the
+    /// same intended close; the backend guarantees at-most-once semantics per
+    /// key.
+    ///
+    /// The backend enforces a rate limit of **5 requests per minute per user**
+    /// on this endpoint; exceeding it returns **HTTP 429**.
     ///
     /// Surfaces backend error codes verbatim (`ARB_POSITION_NOT_FOUND`,
     /// `INVALID_STATUS`).

--- a/src/client.rs
+++ b/src/client.rs
@@ -396,10 +396,11 @@ impl PolyforgeClient {
     }
 
     fn idempotency_key_header(idempotency_key: &str) -> Result<HeaderValue> {
-        if idempotency_key.len() < 8 || idempotency_key.len() > 128 {
+        if idempotency_key.trim().len() < 8 || idempotency_key.len() > 128 {
             return Err(PolyforgeError::Validation(format!(
-                "idempotency_key must be 8–128 characters, got {}",
-                idempotency_key.len()
+                "idempotency_key must be 8–128 non-whitespace characters, got {} ({} after trim)",
+                idempotency_key.len(),
+                idempotency_key.trim().len()
             )));
         }
         HeaderValue::from_str(idempotency_key).map_err(|_| {

--- a/src/types.rs
+++ b/src/types.rs
@@ -178,7 +178,7 @@ pub enum TradingMode {
     Paper,
 }
 
-/// Parameters for [`PolyforgeClient::start_strategy`].
+/// Parameters for [`crate::PolyforgeClient::start_strategy`].
 ///
 /// Platform contract (POST `/api/v1/strategies/{id}/start`):
 /// `{ "mode": "live"|"paper" }`.
@@ -497,12 +497,32 @@ pub struct ListOrdersParams {
     pub to: Option<String>,
 }
 
-/// Parameters for closing a position.
+/// Parameters for closing a prediction-market position.
+///
+/// `size` controls the close mode:
+/// - `None` (default) — **sweep**: close the entire position at market price
+///   by placing a market sell order for the full held quantity.
+/// - `Some("100")` — **partial close**: sell only that number of shares,
+///   leaving the remainder of the position open.
+///
+/// # Sweep semantics
+///
+/// GTC orders are priced at `0.001` SELL / `0.999` BUY and behave as a
+/// **market-equivalent sweep, not a resting limit order**.  Slippage is
+/// bounded only by venue depth at call time, not by the on-paper price.
+/// The fill price is whatever the order book offers at the time of
+/// execution.
+///
+/// For cross-venue arbitrage positions use the dedicated
+/// `POST /api/v1/arbitrage/positions/:id/close` endpoint
+/// (see [`crate::PolyforgeClient::close_arbitrage_position`]); arbitrage closes
+/// are always full sweeps — partial closes are not supported for arb positions.
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct ClosePositionParams {
     #[serde(rename = "tokenId")]
     pub token_id: String,
-    /// Size as a number string (e.g. `"100"`). Platform validates with `@IsNumberString()`.
+    /// Size to close as a number string (e.g. `"100"`).  Omit to sweep the
+    /// entire position.  Platform validates with `@IsNumberString()`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<String>,
 }
@@ -2402,11 +2422,22 @@ pub struct CreateArbitrageAlertParams {
 
 /// Parameters for `POST /api/v1/arbitrage/execute`.
 ///
-/// `match_id` must be a UUID, `size` must be an integer USDC amount in the
-/// `1..=10000` range, and `max_slippage_pct`, if set, must be in `0..=5`.
-/// These mirror the server-side `class-validator` bounds in
-/// `ExecuteArbDto`. Use [`PolyforgeClient::execute_arbitrage`] which validates
-/// before any real-money order hits the wire.
+/// `match_id` must be a valid UUID (RFC 4122).  The backend validates this
+/// server-side and **returns HTTP 400** for non-UUID input.  The SDK also
+/// performs a client-side validation before any real-money order hits the
+/// wire.
+///
+/// `size` must be an integer USDC amount in the `1..=10000` range, and
+/// `max_slippage_pct`, if set, must be in `0..=5`.  These mirror the
+/// server-side `class-validator` bounds in `ExecuteArbDto`.  Use
+/// [`crate::PolyforgeClient::execute_arbitrage`] which validates before
+/// any real-money order hits the wire.
+///
+/// The backend requires an `Idempotency-Key` header (8–128 characters) on
+/// every request; the SDK sends the caller-supplied `idempotency_key`
+/// argument as that header.  See
+/// [`crate::PolyforgeClient::execute_arbitrage`] for rate-limit and error
+/// code details.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecuteArbitrageParams {
@@ -2417,6 +2448,10 @@ pub struct ExecuteArbitrageParams {
 }
 
 /// Lifecycle status for a cross-venue arbitrage position.
+///
+/// Flow: `PENDING` → `OPEN` → `CLOSING` → `CLOSED` (normal path)
+/// or `PENDING` → `OPEN` → `CLOSING` → `FAILED` (close failure).
+/// `PARTIAL` may appear transiently when only one leg has filled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ArbPositionStatus {
@@ -2474,6 +2509,17 @@ pub struct ArbExecutionLeg {
 }
 
 /// Server response for `POST /api/v1/arbitrage/execute`.
+///
+/// On success this opens a new [`ArbPosition`] in `OPEN` state.  The position
+/// consists of two offsetting legs (buy on one venue, sell on the other) and
+/// can later be exited only via a **full sweep-close** using
+/// `POST /api/v1/arbitrage/positions/:id/close`
+/// (see [`crate::PolyforgeClient::close_arbitrage_position`]).  Partial closes
+/// are not supported for arbitrage positions.
+///
+/// Both legs carry optional `intent_id` and `price` fields; fill confirmation
+/// may arrive asynchronously and is available on the full [`ArbPosition`]
+/// record after the orders execute.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ArbExecutionResult {
@@ -2492,6 +2538,12 @@ pub struct ArbExecutionResult {
 }
 
 /// A cross-venue arbitrage position (mirrors the Prisma `ArbPosition` row).
+///
+/// Created via `POST /api/v1/arbitrage/execute` and closed via a **full
+/// sweep-close** (`POST /api/v1/arbitrage/positions/:id/close`).  The
+/// lifecycle is tracked in [`status`](Self::status): positions start in
+/// `OPEN`, transition through `CLOSING` during the sweep, and settle in
+/// `CLOSED` or `FAILED`.
 ///
 /// Decimal columns (`buyPrice`, `buySize`, P&L fields, etc.) arrive as JSON
 /// strings — kept as `Option<String>` for lossless precision.
@@ -2571,6 +2623,19 @@ pub struct ArbPositionsResponse {
 }
 
 /// Server response for `POST /api/v1/arbitrage/positions/:id/close`.
+///
+/// Returned after a **full sweep-close** of a cross-venue arbitrage position.
+/// Both legs (buy and sell) are reversed with market orders placed on the
+/// respective venues.  The close is always a complete sweep — no partial
+/// close is supported for arbitrage positions.
+///
+/// `status` reflects the terminal outcome of the sweep:
+/// - `CLOSED` — both reversing market orders were successfully placed.
+/// - `FAILED` — one or both reverse orders could not be placed (e.g.
+///   insufficient liquidity, venue connectivity issue).
+///
+/// Once closed, call [`crate::PolyforgeClient::get_arbitrage_position`] to
+/// fetch the full position record including fill prices and realised P&L.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ArbCloseResponse {


### PR DESCRIPTION
## Summary

Updates cross-venue arbitrage docstrings across the Rust SDK to match backend hardening from POLA-1911.

### Changes
- **Idempotency-Key** documented as **required** (8-128 chars) on `execute_arbitrage` and `close_arbitrage_position`
- **Sweep semantics** documented verbatim: GTC orders at 0.001 SELL / 0.999 BUY = market-equivalent sweep, not resting limit orders
- **Rate limit** of 5 req/min/user and HTTP 429 path documented
- **match_id UUID validation** documented with HTTP 400 on non-UUID input
- `idempotency_key_header()` validation tightened from non-empty to 8-128 characters
- README arbitrage section expanded with complete execute-and-close code example
- Pre-existing broken intra-doc links fixed (`PolyforgeClient` to `crate::PolyforgeClient`)

### Verification
- 360 tests pass, 0 failures
- 4 doc-tests pass
- `cargo clippy` clean
- `cargo doc` clean with zero warnings

Closes POLA-1958