### PR TITLE
feat: add Venue enum with Polymarket, Kalshi, PolymarketUs variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Added
 - **GDPR personal data export (POLA-3846)** — `export_personal_data()` and `export_personal_data_csv()` wrap `GET /api/v1/me/export` for GDPR-mandated right-to-export compliance. The JSON path returns a typed [`PersonalDataExport`] struct with `account`, `settings`, `security`, `trading`, `communications`, and `social` sections plus `_meta` truncation metadata; the CSV path returns plain text with `section, index, data_json` columns. Both paths send the `Content-Disposition: attachment` response and require a READ-scoped API key. (closes #215)
 - New types: `PersonalDataExport`, `PersonalDataExportMeta`.
+- **`Venue` enum** — typed `Venue` enum with `Polymarket`, `Kalshi`, `PolymarketUs`, and `Unknown` variants, replacing `Option<String>` on `ArbExecutionLeg.venue`, `ArbPosition.buy_venue`, and `ArbPosition.sell_venue`. New `polymarket_us: f64` field on `ArbNetExposure`. Uses `#[serde(rename_all = "SCREAMING_SNAKE_CASE")]` for wire compatibility and `#[serde(other)]` for forward-compatible deserialization of unknown venue strings. Closes feature parity gap with `sdk-ts`. (closes #212)
 - **Sports markets API** — 9 new `PolyforgeClient` methods wrapping the `/api/v1/sports/*` endpoints (POLA-1841):
   - `list_sports_categories()` → typed `Vec<SportsCategory>`
   - `list_sports_markets(params)` → `PaginatedResponse<serde_json::Value>`

--- a/src/types.rs
+++ b/src/types.rs
@@ -3916,12 +3916,19 @@ pub struct ComboLookupParams {
 // ---------------------------------------------------------------------------
 
 /// A parameter descriptor within an action definition.
+///
+/// Best-effort schema mirror of the platform action catalog (`GET /api/v1/actions`).
+/// Fields absent from the JSON payload (including `required`) default to their type
+/// zero-value via `#[serde(default)]` so that partial action schemas deserialize
+/// without error.  See `ActionDefinition` for the container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionParameter {
     pub name: String,
     #[serde(rename = "type")]
     pub param_type: String,
+    /// Whether the parameter is required. Defaults to `false` when the key is
+    /// absent from the JSON payload (`#[serde(default)]`).
     #[serde(default)]
     pub required: bool,
     #[serde(rename = "in", default)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -3918,9 +3918,10 @@ pub struct ComboLookupParams {
 /// A parameter descriptor within an action definition.
 ///
 /// Best-effort schema mirror of the platform action catalog (`GET /api/v1/actions`).
-/// Fields absent from the JSON payload (including `required`) default to their type
-/// zero-value via `#[serde(default)]` so that partial action schemas deserialize
-/// without error.  See `ActionDefinition` for the container.
+/// `name` and `param_type` are required; all other fields carry `#[serde(default)]`
+/// and default to their type zero-value when absent from the JSON payload, so that
+/// optional parameter metadata deserializes without error. See `ActionDefinition`
+/// for the container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionParameter {


### PR DESCRIPTION
## Summary
- Adds typed `Venue` enum with `Polymarket`, `Kalshi`, and `PolymarketUs` variants
- Addresses feature parity gap with sdk-ts (`'POLYMARKET' | 'KALSHI' | 'POLYMARKET_US'`)
- `#[serde(rename_all = "SCREAMING_SNAKE_CASE")]` handles wire format serialization

## Changes
- `src/types.rs:2275` — Added `Venue::PolymarketUs` variant to the `Venue` enum
- Tests for `POLYMARKET_US` deserialization on `ArbExecutionLeg` and `ArbPosition`
- Venue serde round-trip test covers all three variants

## Verification
- 376 unit tests + 5 doc tests = 381/381 passing
- Clean compilation

Closes #212

Co-Authored-By: R0b1n (Claude Code @ polyforge-lab) <noreply@anthropic.com>