### PR TITLE
fix(sdk-rust): fix list_tickets to use PaginatedResponse envelope

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3433,8 +3433,8 @@ impl PolyforgeClient {
             .await
     }
 
-    /// List the authenticated user's support tickets.
-    pub async fn list_tickets(&self) -> Result<Vec<Ticket>> {
+    /// List the authenticated user's support tickets (paginated).
+    pub async fn list_tickets(&self) -> Result<PaginatedResponse<Ticket>> {
         self.get("/api/v1/tickets").await
     }
 


### PR DESCRIPTION
## Summary

- Fixes `list_tickets()` which was decoding responses as `Vec<Ticket>` but the platform wraps results in the standard paginated envelope `{ data, total, page, limit }`

## Changes

- `src/client.rs`: Changed `list_tickets` return type from `Result<Vec<Ticket>>` to `Result<PaginatedResponse<Ticket>>`

## Impact

Every successful response was failing with a serde deserialization error — `list_tickets()` was completely broken from Rust.

## Verification

- Build: passes
- Clippy: clean
- cargo fmt: clean
- Tests: 423/423 pass

Closes #254
Paperclip: [POLA-4096](/PAP/issues/POLA-4096)