### PR TITLE
feat: add twitter_handle field to UpdateProfileParams (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   mirror the controller's `Record<string, unknown>` / `unknown[]` fidelity instead
   of inventing strict shapes.
 - **UpdateSettingsProfileParams.twitter_handle** — add optional `twitter_handle: Option<String>` field. Serializes as `twitterHandle` (camelCase) to match the platform's `UpdateProfileDto` and reach feature parity with `polyforge-sdk-python` and `polyforge-mcp`. (closes #185)
+- **UpdateProfileParams.twitter_handle** — add optional `twitter_handle: Option<String>` field, matching the platform's `UpdateProfileDto` contract on the `PATCH /api/v1/profile/me` endpoint. (closes #255)
 - **Misc public utility endpoints (POLA-1858)** — 18 read/write methods that close the SDK gap matrix from POLA-1845 and bring the Rust SDK to parity with the platform's miscellaneous user/markets/fees/analytics surface:
   - `get_accuracy_overview()` → `GET /api/v1/accuracy` — companion to `get_accuracy()` (`/accuracy/me`); both return the same `AccuracyScore` shape.
   - `get_feed(Option<&GetWhaleFeedParams>)` → `GET /api/v1/feed` — paged whale-trade feed (reuses existing `WhaleTrade` and `GetWhaleFeedParams` types since the controller delegates to `WhalesService.getFeed`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Breaking
+- **UpdateProfileParams.twitter_handle** — adds optional `twitter_handle: Option<String>` field to `UpdateProfileParams`. This is a source-breaking change for downstream callers constructing `UpdateProfileParams` with exhaustive struct literals; add `twitter_handle: None` or use `..Default::default()`. Bumps crate version to **2.0.0**. (closes #255)
+
 ### Changed
 - **Arbitrage docstrings** — updated cross-venue arb docstrings to reflect backend hardening (POLA-1911, POLA-1958):
   - `Idempotency-Key` is now **required** on `execute_arbitrage` and `close_arbitrage_position` (8–128 characters, validated client-side).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyforge"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "http",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyforge"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust SDK for the Polyforge trading platform REST API"

--- a/src/client.rs
+++ b/src/client.rs
@@ -8020,10 +8020,12 @@ mod tests {
             display_name: Some("Alice".into()),
             bio: None,
             avatar_url: None,
+            twitter_handle: None,
         };
         let v = serde_json::to_value(&p).unwrap();
         assert_eq!(v["displayName"], "Alice");
         assert!(v.get("bio").is_none());
+        assert!(v.get("twitterHandle").is_none());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2874,6 +2874,8 @@ pub struct UpdateProfileParams {
     pub bio: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub twitter_handle: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Added optional `twitter_handle: Option<String>` field to `UpdateProfileParams`, used by `PATCH /api/v1/profile/me`
- Field serializes as `twitterHandle` (camelCase) to match the platform's `UpdateProfileDto` contract
- Reaches feature parity with `UpdateSettingsProfileParams` which already includes this field
- Updated existing test to verify `twitterHandle` is correctly excluded from serialization when `None`

## Related
- Closes #255
- Companion to #185 (which added the same field to `UpdateSettingsProfileParams`)