### PR TITLE
feat: add twitter_handle field to UpdateProfileParams (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   `SportsComboLookupParams`. Weakly-typed payloads use `serde_json::Value` to
   mirror the controller's `Record<string, unknown>` / `unknown[]` fidelity instead
   of inventing strict shapes.
+- **UpdateProfileParams.twitter_handle** — add optional `twitter_handle: Option<String>` field. Serializes as `twitterHandle` (camelCase) to match the platform's `UpdateProfileDto` and reach feature parity with `polyforge-sdk-python` and `polyforge-mcp`. (closes #255)
 - **UpdateSettingsProfileParams.twitter_handle** — add optional `twitter_handle: Option<String>` field. Serializes as `twitterHandle` (camelCase) to match the platform's `UpdateProfileDto` and reach feature parity with `polyforge-sdk-python` and `polyforge-mcp`. (closes #185)
 - **Misc public utility endpoints (POLA-1858)** — 18 read/write methods that close the SDK gap matrix from POLA-1845 and bring the Rust SDK to parity with the platform's miscellaneous user/markets/fees/analytics surface:
   - `get_accuracy_overview()` → `GET /api/v1/accuracy` — companion to `get_accuracy()` (`/accuracy/me`); both return the same `AccuracyScore` shape.

--- a/src/client.rs
+++ b/src/client.rs
@@ -8020,10 +8020,39 @@ mod tests {
             display_name: Some("Alice".into()),
             bio: None,
             avatar_url: None,
+            twitter_handle: None,
         };
         let v = serde_json::to_value(&p).unwrap();
         assert_eq!(v["displayName"], "Alice");
         assert!(v.get("bio").is_none());
+        assert!(v.get("twitterHandle").is_none());
+    }
+
+    #[test]
+    fn test_update_profile_serializes_twitter_handle_camel_case() {
+        let p = UpdateProfileParams {
+            display_name: None,
+            bio: None,
+            avatar_url: None,
+            twitter_handle: Some("polyforge".into()),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["twitterHandle"], "polyforge");
+        assert!(v.get("twitter_handle").is_none());
+    }
+
+    #[test]
+    fn test_update_profile_twitter_handle_max_length_50() {
+        let handle = "a".repeat(50);
+        let p = UpdateProfileParams {
+            display_name: None,
+            bio: None,
+            avatar_url: None,
+            twitter_handle: Some(handle.clone()),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["twitterHandle"], handle);
+        assert_eq!(v["twitterHandle"].as_str().unwrap().len(), 50);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2874,6 +2874,8 @@ pub struct UpdateProfileParams {
     pub bio: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub twitter_handle: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Add optional `twitter_handle: Option<String>` field to `UpdateProfileParams`, serializing as `twitterHandle` (camelCase) to match the platform's `UpdateProfileDto`. Reaches feature parity with `polyforge-sdk-python` and `polyforge-mcp`.

## Changes

- `src/types.rs`: Add `twitter_handle` field with `skip_serializing_if` to `UpdateProfileParams`
- `src/client.rs`: Add 3 unit tests (camelCase serialization, max length 50, None omission)
- `CHANGELOG.md`: Add entry for `UpdateProfileParams.twitter_handle`

## Verification

- [x] `cargo build` passes
- [x] `cargo test` — 420 passed, 5 doc tests passed
- [x] `cargo clippy -- -D warnings` clean

Closes #255