### PR TITLE
fix: add twitter_handle to UpdateProfileParams (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   mirror the controller's `Record<string, unknown>` / `unknown[]` fidelity instead
   of inventing strict shapes.
 - **UpdateSettingsProfileParams.twitter_handle** — add optional `twitter_handle: Option<String>` field. Serializes as `twitterHandle` (camelCase) to match the platform's `UpdateProfileDto` and reach feature parity with `polyforge-sdk-python` and `polyforge-mcp`. (closes #185)
+- **UpdateProfileParams.twitter_handle** — add optional `twitter_handle: Option<String>` field to match the platform's profile `UpdateProfileDto` and reach feature parity with `polyforge-sdk-python` and `polyforge-mcp`. (closes #255)
 - **Misc public utility endpoints (POLA-1858)** — 18 read/write methods that close the SDK gap matrix from POLA-1845 and bring the Rust SDK to parity with the platform's miscellaneous user/markets/fees/analytics surface:
   - `get_accuracy_overview()` → `GET /api/v1/accuracy` — companion to `get_accuracy()` (`/accuracy/me`); both return the same `AccuracyScore` shape.
   - `get_feed(Option<&GetWhaleFeedParams>)` → `GET /api/v1/feed` — paged whale-trade feed (reuses existing `WhaleTrade` and `GetWhaleFeedParams` types since the controller delegates to `WhalesService.getFeed`).

--- a/src/client.rs
+++ b/src/client.rs
@@ -8054,10 +8054,25 @@ mod tests {
             display_name: Some("Alice".into()),
             bio: None,
             avatar_url: None,
+            twitter_handle: None,
         };
         let v = serde_json::to_value(&p).unwrap();
         assert_eq!(v["displayName"], "Alice");
         assert!(v.get("bio").is_none());
+        assert!(v.get("twitterHandle").is_none());
+    }
+
+    #[test]
+    fn test_update_profile_params_serializes_twitter_handle_camel_case() {
+        let p = UpdateProfileParams {
+            display_name: None,
+            bio: None,
+            avatar_url: None,
+            twitter_handle: Some("polyforge".into()),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["twitterHandle"], "polyforge");
+        assert!(v.get("twitter_handle").is_none());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2914,6 +2914,8 @@ pub struct UpdateProfileParams {
     pub bio: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub twitter_handle: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Adds the missing `twitter_handle: Option<String>` field to `UpdateProfileParams` to match the platform's `UpdateProfileDto` and reach feature parity with `polyforge-sdk-python` and `polyforge-mcp`.

## Changes

- **`src/types.rs`**: Added `twitter_handle: Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]` to `UpdateProfileParams`
- **`src/client.rs`**: Updated `test_update_profile_params_omits_none_fields` to include `twitter_handle: None` and assert `twitterHandle` is absent when None
- **`src/client.rs`**: Added `test_update_profile_params_serializes_twitter_handle_camel_case` to verify `Some` value serializes correctly as `twitterHandle`
- **`CHANGELOG.md`**: Added entry documenting the new field

## Verification

- All 421 unit tests pass (0 failures)
- Build compiles cleanly
- Field serializes as `twitterHandle` (camelCase) matching the platform contract
- Matches existing `UpdateSettingsProfileParams.twitter_handle` pattern

Closes #255