### PR TITLE
fix(sdk-rust): remove BROKEN_SYNTAX_HERE placeholders and triage uncommitted WIP changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - `idempotency_key_header()` validation tightened from non-empty to 8–128 characters.
 - **Auth behavior for public endpoints** — `get_user_score()`, `get_user_badges()`, `get_user_profile()`, and `get_actions()` now use `get_with_optional_auth()`. When the client is constructed with an empty API key these methods skip the `Authorization` header, matching the platform's public-route contract. `get_health()` uses `get_no_auth()` (never attaches the `Authorization` header). Previously `get_user_score()`, `get_user_badges()`, and `get_user_profile()` always attached `Authorization: Bearer <key>`, causing 401 errors when no key was available.
 - **Cross-SDK naming aliases** — `get_notifications()` is now a deprecated alias for `list_notifications()`, and `ReferralsInfo` is now a deprecated alias for the canonical `MyReferralsResponse` type.
+- **search_markets return type** — `search_markets()` now returns `MarketSearchResponse` (a flat `{ results: [...] }` envelope) instead of `PaginatedResponse<Market>`, matching the platform's actual response shape for `GET /api/v1/markets/search`. New `MarketSearchResponse` type. (POLA-5122)
 - **vote_market_sentiment params** — `vote_market_sentiment()` now accepts `VoteMarketSentimentParams` with `direction` and `confidence` fields instead of sending an empty JSON body, matching the platform's expected request schema for `POST /api/v1/markets/:marketId/sentiment`. (POLA-5122)
 
 ### Added

--- a/src/client.rs
+++ b/src/client.rs
@@ -904,15 +904,11 @@ impl PolyforgeClient {
     }
 
     /// Full-text search across all markets.
-    ///
-    /// The platform returns `{ results: [...] }` rather than the standard
-    /// paginated envelope.  The SDK deserializes into `SearchResults<Market>`
-    /// internally and converts to `PaginatedResponse<Market>` so callers see
-    /// a uniform paginated shape.
+    /// Returns a flat `results` list (not a paginated envelope).
     pub async fn search_markets(
         &self,
         params: &SearchMarketsParams,
-    ) -> Result<PaginatedResponse<Market>> {
+    ) -> Result<MarketSearchResponse> {
         let mut qp: Vec<(&str, String)> = vec![("q", params.q.clone())];
         if let Some(l) = params.limit {
             qp.push(("limit", l.to_string()));
@@ -924,7 +920,9 @@ impl PolyforgeClient {
         let qs = format!("?{}", pairs.join("&"));
         let results: SearchResults<Market> =
             self.get(&format!("/api/v1/markets/search{qs}")).await?;
-        Ok(results.into_paginated_response(params.limit.unwrap_or(20)))
+        Ok(MarketSearchResponse {
+            results: results.results,
+        })
     }
 
     /// Get the minimum price tick size for a market token.

--- a/src/types.rs
+++ b/src/types.rs
@@ -63,6 +63,13 @@ pub struct Token {
     pub price: Option<f64>,
 }
 
+/// Response from `GET /api/v1/markets/search` (flat `results` list, not paginated).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketSearchResponse {
+    pub results: Vec<Market>,
+}
+
 // ---------------------------------------------------------------------------
 // GDPR Personal Data Export (POLA-3846)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes `BROKEN_SYNTAX_HERE` placeholder from uncommitted test code in `src/client.rs`
- Triages stalled WIP compatibility changes (types, validation, search response shape)
- Removes unused partially-implemented types (`AccuracyLeaderboardParams`, `AccuracyLeaderboardEntry`)
- Removes removed helper functions (`validate_drawdown_threshold`, `validate_drawdown_lookback`)
- Changes `search_markets` return type to `MarketSearchResponse` matching the actual platform response

## Verification

- `cargo check --lib` passes
- `cargo test` passes: 425 passed, 0 failed
- `grep -r BROKEN_SYNTAX_HERE` returns nothing

Closes POLA-5121