### PR TITLE
fix: align README install version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Async Rust SDK for the [Polyforge](https://polyforge.io) trading platform REST A
 
 ```toml
 [dependencies]
-polyforge = "2.0"
+polyforge = "3.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -22,7 +22,7 @@ cargo add tokio --features full
 The crate uses `rustls` by default. To use the platform-native TLS instead:
 
 ```toml
-polyforge = { version = "2.0", default-features = false, features = ["native-tls"] }
+polyforge = { version = "3.0", default-features = false, features = ["native-tls"] }
 ```
 
 ## Quick Start

--- a/tests/readme_install_version.rs
+++ b/tests/readme_install_version.rs
@@ -1,0 +1,35 @@
+fn package_major_minor_version() -> String {
+    let cargo_toml = include_str!("../Cargo.toml");
+    let version = cargo_toml
+        .lines()
+        .find_map(|line| line.strip_prefix("version = \""))
+        .and_then(|version| version.split('"').next())
+        .expect("Cargo.toml package version should be present");
+    let mut parts = version.split('.');
+    let major = parts.next().expect("package version should have a major");
+    let minor = parts.next().expect("package version should have a minor");
+
+    format!("{major}.{minor}")
+}
+
+#[test]
+fn readme_install_examples_match_package_major_minor_version() {
+    let readme = include_str!("../README.md");
+    let expected_version = package_major_minor_version();
+
+    for expected_snippet in [
+        format!("polyforge = \"{expected_version}\""),
+        format!("polyforge = {{ version = \"{expected_version}\","),
+    ] {
+        assert!(
+            readme.contains(&expected_snippet),
+            "README.md should include dependency snippet: {expected_snippet}"
+        );
+    }
+
+    assert!(
+        !readme.contains("polyforge = \"2.0\"")
+            && !readme.contains("polyforge = { version = \"2.0\","),
+        "README.md should not point new installs at the previous major version"
+    );
+}


### PR DESCRIPTION
## Summary
- update README install snippets from `polyforge = "2.0"` to the current `3.0` line
- add a focused integration test that checks README install examples against `Cargo.toml` package major/minor version

## Verification
- `cargo fmt --check`
- `cargo test --test readme_install_version`
- `git diff --check`
- `gitleaks protect --staged --redact`
- GitNexus impact: README `Installation` LOW, 0 direct dependents / 0 affected processes

Paperclip: POLA-7217