### PR TITLE
[codex] Add strategy health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 
 ### Added
 - **`CreateStrategyParams.kalshi_subaccount`** — adds an optional `kalshi_subaccount: Option<u64>` field to `CreateStrategyParams`, serialized as `kalshiSubaccount` (camelCase) and omitted when `None`. Enables passing a Kalshi subaccount identifier when creating strategies. `CreateStrategyParams` has a `new(name)` constructor and derives `Default` for forward-compatible construction. (closes #4178)
+- **Strategy health endpoint (POLA-9105 / #301)** — add `get_strategy_health(id)` for
+  `GET /api/v1/strategies/{id}/health`, returning the new typed
+  `StrategyHealth` metrics payload.
 - **GDPR personal data export (POLA-3846)** — `export_personal_data()` and `export_personal_data_csv()` wrap `GET /api/v1/me/export` for GDPR-mandated right-to-export compliance. The JSON path returns a typed [`PersonalDataExport`] struct with `account`, `settings`, `security`, `trading`, `communications`, and `social` sections plus `_meta` truncation metadata; the CSV path returns plain text with `section, index, data_json` columns. Both paths send the `Content-Disposition: attachment` response and require a READ-scoped API key. (closes #215)
 - New types: `PersonalDataExport`, `PersonalDataExportMeta`.
 - **Sports markets API** — 9 new `PolyforgeClient` methods wrapping the `/api/v1/sports/*` endpoints (POLA-1841):

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ async fn main() -> polyforge::Result<()> {
 | `get_strategy(id)` | Get a strategy by ID |
 | `create_strategy(name, description)` | Create a new strategy |
 | `create_strategy_from_description(desc, market_id)` | AI-powered strategy creation |
+| `get_strategy_health(id)` | Get execution health metrics for a strategy |
 | `start_strategy(id, mode)` | Start a strategy (live or paper) |
 | `stop_strategy(id)` | Stop a running strategy |
 | `get_strategy_templates()` | List available templates |

--- a/src/client.rs
+++ b/src/client.rs
@@ -1024,6 +1024,12 @@ impl PolyforgeClient {
             .await
     }
 
+    /// Get execution health metrics for a strategy.
+    pub async fn get_strategy_health(&self, id: &str) -> Result<StrategyHealth> {
+        self.get(&format!("/api/v1/strategies/{}/health", encode(id)))
+            .await
+    }
+
     /// Create a new strategy with full block configuration.
     ///
     /// Use [`CreateStrategyParams`] to specify blocks, visibility, execution mode,
@@ -5640,6 +5646,38 @@ mod tests {
     }
 
     #[test]
+    fn test_strategy_health_deserializes() {
+        let json = r#"{"fillRate":98.5,"avgLatencyMs":120,"errorCount24h":1,"slippageBps":2.5,"winRate":57.25,"totalPnl":1234.56,"maxDrawdown":-42.0,"totalOrders":20,"filledOrders":19,"lastUpdated":"2026-05-20T12:00:00Z"}"#;
+        let health: StrategyHealth = serde_json::from_str(json).unwrap();
+        assert_eq!(health.fill_rate, Some(98.5));
+        assert_eq!(health.avg_latency_ms, 120);
+        assert_eq!(health.error_count_24h, 1);
+        assert_eq!(health.slippage_bps, 2.5);
+        assert_eq!(health.win_rate, Some(57.25));
+        assert_eq!(health.total_pnl, Some(1234.56));
+        assert_eq!(health.max_drawdown, Some(-42.0));
+        assert_eq!(health.total_orders, 20);
+        assert_eq!(health.filled_orders, 19);
+        assert_eq!(health.last_updated.as_deref(), Some("2026-05-20T12:00:00Z"));
+    }
+
+    #[test]
+    fn test_strategy_health_deserializes_platform_placeholder_nulls() {
+        let json = r#"{"fillRate":null,"avgLatencyMs":0,"errorCount24h":0,"slippageBps":0,"winRate":null,"totalPnl":null,"maxDrawdown":null,"totalOrders":0,"filledOrders":0,"lastUpdated":null}"#;
+        let health: StrategyHealth = serde_json::from_str(json).unwrap();
+        assert_eq!(health.fill_rate, None);
+        assert_eq!(health.avg_latency_ms, 0);
+        assert_eq!(health.error_count_24h, 0);
+        assert_eq!(health.slippage_bps, 0.0);
+        assert_eq!(health.win_rate, None);
+        assert_eq!(health.total_pnl, None);
+        assert_eq!(health.max_drawdown, None);
+        assert_eq!(health.total_orders, 0);
+        assert_eq!(health.filled_orders, 0);
+        assert_eq!(health.last_updated, None);
+    }
+
+    #[test]
     fn test_paginated_response_deserializes_strategies() {
         let json = r#"{
             "data": [{"id":"s1","name":"Alpha"},{"id":"s2","name":"Beta"}],
@@ -9435,6 +9473,26 @@ mod tests {
         })
         .await;
         assert!(request.contains("GET /api/v1/status HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn test_get_strategy_health_path_and_auth() {
+        let response_json = r#"{"fillRate":null,"avgLatencyMs":0,"errorCount24h":0,"slippageBps":0,"winRate":null,"totalPnl":null,"maxDrawdown":null,"totalOrders":0,"filledOrders":0,"lastUpdated":null}"#;
+        let request = capture_request(response_json, |client| async move {
+            client.get_strategy_health("strategy/id").await.map(|_| ())
+        })
+        .await;
+        assert!(
+            request.contains("GET /api/v1/strategies/strategy%2Fid/health HTTP/1.1"),
+            "request must hit encoded strategy health path; got: {}",
+            request.lines().next().unwrap_or("")
+        );
+        let auth = captured_header(&request, "Authorization")
+            .expect("get_strategy_health must include Authorization header");
+        assert!(
+            auth.starts_with("Bearer "),
+            "Authorization must be Bearer token"
+        );
     }
 
     #[tokio::test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -327,6 +327,24 @@ pub struct StrategyStatusResponse {
     pub extra: serde_json::Value,
 }
 
+/// Execution health metrics for a strategy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyHealth {
+    pub fill_rate: Option<f64>,
+    pub avg_latency_ms: u64,
+    pub error_count_24h: u64,
+    pub slippage_bps: f64,
+    pub win_rate: Option<f64>,
+    pub total_pnl: Option<f64>,
+    pub max_drawdown: Option<f64>,
+    pub total_orders: u64,
+    pub filled_orders: u64,
+    pub last_updated: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
 /// A strategy template with block configuration and popularity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Summary
- add `PolyforgeClient::get_strategy_health(id)` for `GET /api/v1/strategies/{id}/health`
- add typed `StrategyHealth` with camelCase serde mapping and forward-compatible `extra` data
- document the new strategy method in README and CHANGELOG

## Why
The platform exposes strategy execution health metrics, but the Rust SDK did not provide a first-class method for consumers to call the endpoint.

Closes #301.

## Review
- R0B1N-APPROVED on POLA-9105 after scoped implementation review

## Verification
- `cargo fmt --check`
- `git diff --cached --check`
- added-line static security scan: no matches
- `timeout 300 cargo test strategy_health -- --nocapture` (3 passed)
- `timeout 300 cargo check`
- GitNexus targeted impact: LOW for `get_strategy_health`, `StrategyHealth`, and `PolyforgeClient`
- GitNexus staged detect-changes reported CRITICAL due broad file/section mapping; concrete staged diff was limited to `CHANGELOG.md`, `README.md`, `src/client.rs`, and `src/types.rs`
- `npx gitnexus analyze` succeeded after one lock retry
