### PR TITLE
Fix list_smart_orders response type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - **Webhook active alias** — `Webhook.enabled` now deserializes from platform `"active"` responses, matching the actual webhook payload shape while preserving the Rust SDK field name. (closes #306)
+- **list_smart_orders response type** — `list_smart_orders()` now returns `Vec<SmartOrder>` instead of `PaginatedResponse<SmartOrder>`, matching the bare array returned by `GET /api/v1/orders/smart`. (closes #303)
 - **search_markets response shape** — `search_markets()` now returns `SearchMarketsResponse { results: Vec<Market> }` instead of `PaginatedResponse<Market>`, matching the platform's actual `{ "results": [...] }` envelope. `MarketSearchResponse` is retained as a deprecated alias for backward compatibility. (#253)
 - **ConditionalOrder type alias** — `ConditionalOrder.condition_type` now accepts `"type"` as a serde alias, matching the platform's actual field name in `GET /api/v1/conditional-orders` responses. (POLA-5122)
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2158,7 +2158,7 @@ impl PolyforgeClient {
     }
 
     /// List your smart orders with child order progress.
-    pub async fn list_smart_orders(&self) -> Result<PaginatedResponse<SmartOrder>> {
+    pub async fn list_smart_orders(&self) -> Result<Vec<SmartOrder>> {
         self.get("/api/v1/orders/smart").await
     }
 
@@ -5811,6 +5811,41 @@ mod tests {
             result.is_err(),
             "bare array must not deserialize as PaginatedResponse"
         );
+    }
+
+    #[test]
+    fn test_smart_order_list_deserializes_bare_array() {
+        // #303: GET /api/v1/orders/smart returns a bare array, not PaginatedResponse.
+        let json = r#"[
+            {
+                "id": "so-1",
+                "type": "TWAP",
+                "status": "ACTIVE",
+                "marketId": "m-1",
+                "tokenId": "t-1",
+                "outcome": "YES",
+                "side": "BUY",
+                "totalSize": "10",
+                "slicesFilled": 1,
+                "slicesTotal": 5,
+                "nextExecuteAt": "2026-05-24T03:00:00Z",
+                "createdAt": "2026-05-24T02:00:00Z",
+                "orders": [
+                    {
+                        "id": "order-1",
+                        "status": "FILLED",
+                        "fillSize": "2",
+                        "fillPrice": "0.45",
+                        "createdAt": "2026-05-24T02:30:00Z"
+                    }
+                ]
+            }
+        ]"#;
+        let resp: Vec<SmartOrder> = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.len(), 1);
+        assert_eq!(resp[0].id, "so-1");
+        assert_eq!(resp[0].orders.len(), 1);
+        assert_eq!(resp[0].orders[0].id, "order-1");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Change `list_smart_orders` to return `Vec<SmartOrder>` for the bare array returned by `GET /api/v1/orders/smart`
- Add a regression test that deserializes the platform response shape
- Document the compatibility fix in the changelog

Closes #303

## Verification
- `cargo test test_smart_order_list_deserializes_bare_array`

## GitNexus
- `impact list_smart_orders --direction upstream --repo polyforge-sdk-rust`: LOW risk, 0 direct callers, 0 affected processes, 0 affected modules
- `detect-changes` via `gitnexus@1.6.5` completed but reported no mapped changes, likely stale line mapping; scoped git diff is limited to `CHANGELOG.md` and `src/client.rs`
