### PR TITLE
fix: return Order from update_order_journal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
   - `get_market_history(market_id, Option<MarketHistoryPeriod>)` → `GET /api/v1/markets/{marketId}/history` — `period` ∈ `1d | 7d | 30d | 90d`, defaults to `7d` server-side.
   - `get_market_sentiment_report(market_id)` → `GET /api/v1/markets/{marketId}/sentiment` — markets-controller sentiment report with `yesPercent`, `noPercent`, `totalVotes`, and nullable `userVote`. Method is named distinctly from the existing `get_market_sentiment(market_id)` (which still hits the news-controller `/news/sentiment/:marketId`) to avoid silently breaking callers.
   - `vote_market_sentiment(market_id)` → `POST /api/v1/markets/{marketId}/sentiment`.
-  - `update_order_journal(order_id, &UpdateOrderJournalParams)` → `PATCH /api/v1/orders/{id}/journal`.
+  - `update_order_journal(order_id, &UpdateOrderJournalParams)` → `PATCH /api/v1/orders/{id}/journal`, returning the full updated `Order`.
   - `list_combo_collections(Option<&ListComboCollectionsParams>)` → `GET /api/v1/markets/combo/collections` — Kalshi combo collections with optional `seriesTicker`/`limit`/`cursor` filters.
   - `get_combo_collection(ticker)` → `GET /api/v1/markets/combo/collections/{ticker}`.
   - `lookup_combo_market(&ComboLookupParams)` → `POST /api/v1/markets/combo/lookup` — `legs[].outcome` must be `"yes"` or `"no"` (lowercase) to match the server enum.

--- a/src/client.rs
+++ b/src/client.rs
@@ -3925,11 +3925,14 @@ impl PolyforgeClient {
 
     /// Attach or update the journal note + mood on one of the user's orders
     /// (`PATCH /api/v1/orders/:id/journal`).
+    ///
+    /// Returns the full updated order. Journal annotation fields returned by
+    /// the platform are preserved in [`Order::extra`].
     pub async fn update_order_journal(
         &self,
         order_id: &str,
         params: &UpdateOrderJournalParams,
-    ) -> Result<JournalEntry> {
+    ) -> Result<Order> {
         self.patch(
             &format!("/api/v1/orders/{}/journal", encode(order_id)),
             &serde_json::to_value(params)?,
@@ -10419,6 +10422,46 @@ mod tests {
         let v = serde_json::to_value(&p).unwrap();
         assert_eq!(v["mood"], "DISCIPLINED");
         assert!(v.get("note").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_order_journal_returns_updated_order() {
+        fn assert_returns_order<F>(_future: F)
+        where
+            F: Future<Output = Result<Order>>,
+        {
+        }
+
+        let client = PolyforgeClient::new("k").unwrap();
+        let params = UpdateOrderJournalParams {
+            mood: OrderJournalMood::Confident,
+            note: Some("High conviction".into()),
+        };
+        assert_returns_order(client.update_order_journal("order-1", &params));
+
+        let order: Order = serde_json::from_value(serde_json::json!({
+            "id": "order-1",
+            "marketId": "market-1",
+            "side": "BUY",
+            "size": "10",
+            "price": "0.55",
+            "status": "CONFIRMED",
+            "mood": "CONFIDENT",
+            "note": "High conviction"
+        }))
+        .unwrap();
+
+        assert_eq!(order.id, "order-1");
+        assert_eq!(order.market_id.as_deref(), Some("market-1"));
+        assert_eq!(order.status, Some(OrderStatus::Confirmed));
+        assert_eq!(
+            order.extra.get("mood").and_then(|value| value.as_str()),
+            Some("CONFIDENT")
+        );
+        assert_eq!(
+            order.extra.get("note").and_then(|value| value.as_str()),
+            Some("High conviction")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change `update_order_journal` to return the full updated `Order` returned by `PATCH /api/v1/orders/{id}/journal`.
- Document that journal annotation fields are preserved in `Order::extra`.
- Add a focused regression test covering the return type and journal fields on the order response.

## Verification
- `timeout 300 cargo test update_order_journal` passed in the Paperclip task heartbeat before publication.
- GitNexus impact for `update_order_journal`: LOW risk, 0 direct callers, 0 affected processes, 0 affected modules.

Closes #297
