### PR TITLE
Fix webhook active deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **`CreateStrategyParams` new field** — `kalshi_subaccount: Option<u64>` added. Any code that constructs `CreateStrategyParams` with an exhaustive struct literal without `..Default::default()` must add the new field. Use [`CreateStrategyParams::new`] or `..Default::default()` for forward-compatible construction.
 
 ### Fixed
+- **Webhook active alias** — `Webhook.enabled` now deserializes from platform `"active"` responses, matching the actual webhook payload shape while preserving the Rust SDK field name. (closes #306)
 - **search_markets response shape** — `search_markets()` now returns `SearchMarketsResponse { results: Vec<Market> }` instead of `PaginatedResponse<Market>`, matching the platform's actual `{ "results": [...] }` envelope. `MarketSearchResponse` is retained as a deprecated alias for backward compatibility. (#253)
 - **ConditionalOrder type alias** — `ConditionalOrder.condition_type` now accepts `"type"` as a serde alias, matching the platform's actual field name in `GET /api/v1/conditional-orders` responses. (POLA-5122)
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -6317,6 +6317,18 @@ mod tests {
         assert_eq!(result.extra["latencyMs"], 42);
     }
 
+    #[test]
+    fn test_webhook_active_alias_populates_enabled() {
+        let json = r#"{"id":"wh_1","url":"https://example.com/webhook","events":["ORDER_FILLED"],"active":true,"createdAt":"2026-06-01T00:00:00Z"}"#;
+        let webhook: Webhook = serde_json::from_str(json).unwrap();
+
+        assert_eq!(webhook.id, "wh_1");
+        assert_eq!(webhook.enabled, Some(true));
+        assert_eq!(webhook.events, vec![WebhookEvent::OrderFilled]);
+        assert_eq!(webhook.created_at.as_deref(), Some("2026-06-01T00:00:00Z"));
+        assert!(webhook.extra.get("active").is_none());
+    }
+
     // --- Price history & order book (closes #54) ---
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -913,7 +913,7 @@ pub struct Webhook {
     pub url: Option<String>,
     #[serde(default)]
     pub events: Vec<WebhookEvent>,
-    #[serde(default)]
+    #[serde(default, alias = "active")]
     pub enabled: Option<bool>,
     #[serde(default, skip_serializing)]
     pub secret: Option<String>,


### PR DESCRIPTION
## Summary
- Deserialize platform `active` webhook responses into `Webhook.enabled` with a serde alias
- Add a regression test for the `active` response field
- Document the compatibility fix in the changelog

## Verification
- `cargo test test_webhook_active_alias_populates_enabled`

Closes #306