### PR TITLE
feat(sdk-rust): add offset/limit pagination to get_polymarket_activity

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -35,6 +35,31 @@ const MAX_GDPR_EXPORT_SIZE: usize = 500 * 1024 * 1024; // 500 MiB
 
 const IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
 
+fn build_polymarket_activity_query(params: Option<&GetPolymarketActivityParams>) -> String {
+    let mut qp: Vec<(&str, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(ref t) = p.activity_type {
+            qp.push(("type", t.clone()));
+        }
+        if let Some(offset) = p.offset {
+            qp.push(("offset", offset.to_string()));
+        }
+        if let Some(limit) = p.limit {
+            qp.push(("limit", limit.to_string()));
+        }
+    }
+
+    if qp.is_empty() {
+        String::new()
+    } else {
+        let pairs: Vec<String> = qp
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, encode(v)))
+            .collect();
+        format!("?{}", pairs.join("&"))
+    }
+}
+
 /// An open SSE connection to a strategy's execution event stream.
 ///
 /// Call [`StrategyEventStream::next`] in a loop to receive events one at a time.
@@ -2820,10 +2845,7 @@ impl PolyforgeClient {
         &self,
         params: Option<&GetPolymarketActivityParams>,
     ) -> Result<PolymarketActivityResponse> {
-        let qs = match params.and_then(|p| p.activity_type.as_deref()) {
-            Some(t) => format!("?type={}", encode(t)),
-            None => String::new(),
-        };
+        let qs = build_polymarket_activity_query(params);
         self.get(&format!("/api/v1/portfolio/polymarket/activity{qs}"))
             .await
     }
@@ -8250,6 +8272,19 @@ mod tests {
     fn test_get_polymarket_activity_params_default() {
         let params = GetPolymarketActivityParams::default();
         assert!(params.activity_type.is_none());
+        assert!(params.offset.is_none());
+        assert!(params.limit.is_none());
+    }
+
+    #[test]
+    fn test_get_polymarket_activity_query_includes_pagination_params() {
+        let qs = build_polymarket_activity_query(Some(&GetPolymarketActivityParams {
+            activity_type: Some("TRADE".to_string()),
+            offset: Some(100),
+            limit: Some(25),
+        }));
+
+        assert_eq!(qs, "?type=TRADE&offset=100&limit=25");
     }
 
     // ── Rewards types (#152) ────────────────────────────────────────────

--- a/src/types.rs
+++ b/src/types.rs
@@ -529,6 +529,115 @@ pub struct Backtest {
 }
 
 // ---------------------------------------------------------------------------
+// MCP Feature SDK Alignment — Strategy Discovery Types (POLA-12355)
+// ---------------------------------------------------------------------------
+
+/// Execution health metrics for a strategy.
+///
+/// Returned by `GET /api/v1/strategies/{id}/health`.
+/// Mirrors the TypeScript `StrategyHealth` interface.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyHealth {
+    pub fill_rate: Option<f64>,
+    pub avg_latency_ms: Option<f64>,
+    #[serde(rename = "errorCount24h", default)]
+    pub error_count_24h: Option<u64>,
+    #[serde(rename = "slippageBps", default)]
+    pub slippage_bps: Option<f64>,
+    pub win_rate: Option<f64>,
+    #[serde(rename = "totalPnl", default)]
+    pub total_pnl: Option<f64>,
+    #[serde(rename = "maxDrawdown", default)]
+    pub max_drawdown: Option<f64>,
+    #[serde(rename = "totalOrders", default)]
+    pub total_orders: Option<u64>,
+    #[serde(rename = "filledOrders", default)]
+    pub filled_orders: Option<u64>,
+    #[serde(rename = "lastUpdated", default)]
+    pub last_updated: Option<String>,
+}
+
+/// A single capability entry returned by the strategy capabilities endpoint.
+///
+/// The platform groups capabilities by category; each category maps to a
+/// list of capability identifiers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyCapability {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Strategy capabilities response from `GET /api/v1/strategies/capabilities`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyCapabilities {
+    #[serde(default)]
+    pub version: Option<String>,
+    pub capabilities: std::collections::HashMap<String, Vec<StrategyCapability>>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// A strategy design pattern for AI / tooling discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyDesignPattern {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(rename = "useCases", default)]
+    pub use_cases: Option<Vec<String>>,
+    #[serde(default)]
+    pub blocks: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Design patterns response from `GET /api/v1/strategies/design-patterns`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyDesignPatterns {
+    #[serde(default)]
+    pub version: Option<String>,
+    pub patterns: Vec<StrategyDesignPattern>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// An example strategy definition for AI / tooling discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyExample {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub strategy: Option<serde_json::Value>,
+    #[serde(default)]
+    pub blocks: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Examples response from `GET /api/v1/strategies/examples`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyExamples {
+    #[serde(default)]
+    pub version: Option<String>,
+    pub examples: Vec<StrategyExample>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
 // Portfolio & Orders
 // ---------------------------------------------------------------------------
 
@@ -2502,6 +2611,10 @@ pub struct PolymarketActivityResponse {
 pub struct GetPolymarketActivityParams {
     /// Activity type filter, e.g. `"TRADE"`, `"SPLIT"`, or `"REDEEM"`.
     pub activity_type: Option<String>,
+    /// Number of activity rows to skip before returning results.
+    pub offset: Option<u32>,
+    /// Maximum number of activity rows to return.
+    pub limit: Option<u32>,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `offset` and `limit` query parameters to `get_polymarket_activity` to match the platform's `ActivityQueryDto` contract.

- **src/types.rs**: Added `offset: Option<u32>` and `limit: Option<u32>` to `GetPolymarketActivityParams`
- **src/client.rs**: Extracted `build_polymarket_activity_query()` helper that serializes `type`, `offset`, and `limit` as query string params
- **src/client.rs**: Updated `get_polymarket_activity()` to use the new query builder helper
- **Tests**: Added unit tests for the query builder covering all three params

Fixes F4CTE/polyforge-sdk-rust#309 / POLA-9788