### PR TITLE
fix(sdk-rust): repair corrupted Cargo.lock and duplicate type/function definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,15 +56,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,35 +125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -916,7 +878,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1049,7 +1011,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1209,6 +1171,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,17 +1189,6 @@ checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest",
  "keccak",
-]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -1320,7 +1282,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1503,6 +1465,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"
@@ -1765,16 +1747,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1792,31 +1765,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1826,22 +1782,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1850,22 +1794,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1874,22 +1806,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1898,22 +1818,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,31 +36,6 @@ const MAX_GDPR_EXPORT_SIZE: usize = 500 * 1024 * 1024; // 500 MiB
 
 const IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
 
-fn build_polymarket_activity_query(params: Option<&GetPolymarketActivityParams>) -> String {
-    let mut qp: Vec<(&str, String)> = Vec::new();
-    if let Some(p) = params {
-        if let Some(ref t) = p.activity_type {
-            qp.push(("type", t.clone()));
-        }
-        if let Some(offset) = p.offset {
-            qp.push(("offset", offset.to_string()));
-        }
-        if let Some(limit) = p.limit {
-            qp.push(("limit", limit.to_string()));
-        }
-    }
-
-    if qp.is_empty() {
-        String::new()
-    } else {
-        let pairs: Vec<String> = qp
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, encode(v)))
-            .collect();
-        format!("?{}", pairs.join("&"))
-    }
-}
-
 /// An open SSE connection to a strategy's execution event stream.
 ///
 /// Call [`StrategyEventStream::next`] in a loop to receive events one at a time.
@@ -5924,14 +5899,14 @@ mod tests {
         let json = r#"{"fillRate":98.5,"avgLatencyMs":120,"errorCount24h":1,"slippageBps":2.5,"winRate":57.25,"totalPnl":1234.56,"maxDrawdown":-42.0,"totalOrders":20,"filledOrders":19,"lastUpdated":"2026-05-20T12:00:00Z"}"#;
         let health: StrategyHealth = serde_json::from_str(json).unwrap();
         assert_eq!(health.fill_rate, Some(98.5));
-        assert_eq!(health.avg_latency_ms, 120);
-        assert_eq!(health.error_count_24h, 1);
-        assert_eq!(health.slippage_bps, 2.5);
+        assert_eq!(health.avg_latency_ms, Some(120.0));
+        assert_eq!(health.error_count_24h, Some(1));
+        assert_eq!(health.slippage_bps, Some(2.5));
         assert_eq!(health.win_rate, Some(57.25));
         assert_eq!(health.total_pnl, Some(1234.56));
         assert_eq!(health.max_drawdown, Some(-42.0));
-        assert_eq!(health.total_orders, 20);
-        assert_eq!(health.filled_orders, 19);
+        assert_eq!(health.total_orders, Some(20));
+        assert_eq!(health.filled_orders, Some(19));
         assert_eq!(health.last_updated.as_deref(), Some("2026-05-20T12:00:00Z"));
     }
 
@@ -5940,14 +5915,14 @@ mod tests {
         let json = r#"{"fillRate":null,"avgLatencyMs":0,"errorCount24h":0,"slippageBps":0,"winRate":null,"totalPnl":null,"maxDrawdown":null,"totalOrders":0,"filledOrders":0,"lastUpdated":null}"#;
         let health: StrategyHealth = serde_json::from_str(json).unwrap();
         assert_eq!(health.fill_rate, None);
-        assert_eq!(health.avg_latency_ms, 0);
-        assert_eq!(health.error_count_24h, 0);
-        assert_eq!(health.slippage_bps, 0.0);
+        assert_eq!(health.avg_latency_ms, Some(0.0));
+        assert_eq!(health.error_count_24h, Some(0));
+        assert_eq!(health.slippage_bps, Some(0.0));
         assert_eq!(health.win_rate, None);
         assert_eq!(health.total_pnl, None);
         assert_eq!(health.max_drawdown, None);
-        assert_eq!(health.total_orders, 0);
-        assert_eq!(health.filled_orders, 0);
+        assert_eq!(health.total_orders, Some(0));
+        assert_eq!(health.filled_orders, Some(0));
         assert_eq!(health.last_updated, None);
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -336,24 +336,6 @@ pub struct StrategyStatusResponse {
     pub extra: serde_json::Value,
 }
 
-/// Execution health metrics for a strategy.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct StrategyHealth {
-    pub fill_rate: Option<f64>,
-    pub avg_latency_ms: u64,
-    pub error_count_24h: u64,
-    pub slippage_bps: f64,
-    pub win_rate: Option<f64>,
-    pub total_pnl: Option<f64>,
-    pub max_drawdown: Option<f64>,
-    pub total_orders: u64,
-    pub filled_orders: u64,
-    pub last_updated: Option<String>,
-    #[serde(flatten)]
-    pub extra: serde_json::Value,
-}
-
 /// A strategy template with block configuration and popularity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -524,94 +506,6 @@ pub struct Backtest {
     pub created_at: Option<String>,
     #[serde(default)]
     pub completed_at: Option<String>,
-    #[serde(flatten)]
-    pub extra: serde_json::Value,
-}
-
-/// A single capability entry returned by the strategy capabilities endpoint.
-///
-/// The platform groups capabilities by category; each category maps to a
-/// list of capability identifiers.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StrategyCapability {
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub version: Option<String>,
-    #[serde(flatten)]
-    pub extra: serde_json::Value,
-}
-
-/// Strategy capabilities response from `GET /api/v1/strategies/capabilities`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StrategyCapabilities {
-    #[serde(default)]
-    pub version: Option<String>,
-    #[serde(default)]
-    pub capabilities: std::collections::HashMap<String, Vec<StrategyCapability>>,
-    #[serde(default)]
-    pub items: Vec<serde_json::Value>,
-    #[serde(flatten)]
-    pub extra: serde_json::Value,
-}
-
-/// A strategy design pattern for AI / tooling discovery.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StrategyDesignPattern {
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(rename = "useCases", default)]
-    pub use_cases: Option<Vec<String>>,
-    #[serde(default)]
-    pub blocks: Option<serde_json::Value>,
-    #[serde(flatten)]
-    pub extra: serde_json::Value,
-}
-
-/// Design patterns response from `GET /api/v1/strategies/design-patterns`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StrategyDesignPatterns {
-    #[serde(default)]
-    pub version: Option<String>,
-    #[serde(default)]
-    pub patterns: Vec<StrategyDesignPattern>,
-    #[serde(default)]
-    pub items: Vec<serde_json::Value>,
-    #[serde(flatten)]
-    pub extra: serde_json::Value,
-}
-
-/// An example strategy definition for AI / tooling discovery.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StrategyExample {
-    pub name: String,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub strategy: Option<serde_json::Value>,
-    #[serde(default)]
-    pub blocks: Option<serde_json::Value>,
-    #[serde(flatten)]
-    pub extra: serde_json::Value,
-}
-
-/// Examples response from `GET /api/v1/strategies/examples`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StrategyExamples {
-    #[serde(default)]
-    pub version: Option<String>,
-    #[serde(default)]
-    pub examples: Vec<StrategyExample>,
-    #[serde(default)]
-    pub items: Vec<serde_json::Value>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -4447,22 +4341,6 @@ pub enum MarketSentimentDirection {
 #[serde(rename_all = "camelCase")]
 pub struct VoteMarketSentimentParams {
     pub direction: MarketSentimentDirection,
-    pub confidence: i32,
-}
-
-/// Request body for `POST /api/v1/markets/:marketId/sentiment`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct VoteMarketSentimentParams {
-    pub direction: String,
-    pub confidence: i32,
-}
-
-/// Request body for `POST /api/v1/markets/:marketId/sentiment`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct VoteMarketSentimentParams {
-    pub direction: String,
     pub confidence: i32,
 }
 


### PR DESCRIPTION
## Summary

- **Cargo.lock**: deduplicated 21+ duplicate `[[package]]` entries (block-buffer, crypto-common, displaydoc, getrandom, etc.) caused by a bad merge; resolved checksum mismatches via `cargo update`
- **src/types.rs**: removed duplicate `VoteMarketSentimentParams` struct definitions (kept the typed `MarketSentimentDirection` enum version from POLA-12355)
- **src/client.rs**: removed duplicate `build_polymarket_activity_query` function definition; wrapped bare `assert_eq` values in `Some()` for `Option<f64>`/`Option<u64>` `StrategyHealth` fields

## Verification

- `cargo check --all-targets --all-features` — passes with 0 errors (1 pre-existing unused-test warning)
- `cargo clippy --all-targets --all-features` — clean