### PR TITLE
fix: align ticket message fields with platform

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -9628,8 +9628,12 @@ mod tests {
         assert_eq!(transition.author.as_deref(), Some("support"));
         assert_eq!(transition.is_admin, Some(true));
         assert_eq!(transition.is_staff, Some(true));
+        let serialized_transition = serde_json::to_string(&transition).unwrap();
+        assert_eq!(serialized_transition.matches("senderName").count(), 1);
+        assert_eq!(serialized_transition.matches("isAdmin").count(), 1);
 
-        let null_json = r#"{"id":"msg-3","senderName":null,"isAdmin":null}"#;
+        let null_json =
+            r#"{"id":"msg-3","senderName":null,"author":"legacy","isAdmin":null,"isStaff":true}"#;
         let null_message: TicketMessage = serde_json::from_str(null_json).unwrap();
         assert_eq!(null_message.sender_name, None);
         assert_eq!(null_message.author, None);
@@ -9637,6 +9641,15 @@ mod tests {
         assert_eq!(null_message.is_staff, None);
         assert!(null_message.extra["senderName"].is_null());
         assert!(null_message.extra["isAdmin"].is_null());
+
+        let legacy_json = r#"{"id":"msg-4","author":"legacy","isStaff":true}"#;
+        let legacy_message: TicketMessage = serde_json::from_str(legacy_json).unwrap();
+        assert_eq!(legacy_message.sender_name.as_deref(), Some("legacy"));
+        assert_eq!(legacy_message.author.as_deref(), Some("legacy"));
+        assert_eq!(legacy_message.is_admin, Some(true));
+        assert_eq!(legacy_message.is_staff, Some(true));
+        assert!(legacy_message.extra.get("senderName").is_none());
+        assert!(legacy_message.extra.get("isAdmin").is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/src/client.rs
+++ b/src/client.rs
@@ -9612,9 +9612,11 @@ mod tests {
 
     #[test]
     fn test_ticket_message_deserializes() {
-        let json = r#"{"id":"msg-1","ticketId":"t-1","body":"We are looking into it.","author":"support","isStaff":true,"createdAt":"2026-04-02"}"#;
+        let json = r#"{"id":"msg-1","ticketId":"t-1","body":"We are looking into it.","senderName":"support","isAdmin":true,"createdAt":"2026-04-02"}"#;
         let m: TicketMessage = serde_json::from_str(json).unwrap();
         assert_eq!(m.id, "msg-1");
+        assert_eq!(m.is_admin, Some(true));
+        assert_eq!(m.sender_name.as_deref(), Some("support"));
         assert_eq!(m.is_staff, Some(true));
         assert_eq!(m.author.as_deref(), Some("support"));
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -9619,6 +9619,15 @@ mod tests {
         assert_eq!(m.sender_name.as_deref(), Some("support"));
         assert_eq!(m.is_staff, Some(true));
         assert_eq!(m.author.as_deref(), Some("support"));
+        assert_eq!(m.extra["senderName"], "support");
+        assert_eq!(m.extra["isAdmin"], true);
+
+        let transition_json = r#"{"id":"msg-2","senderName":"support","author":"legacy","isAdmin":true,"isStaff":false}"#;
+        let transition: TicketMessage = serde_json::from_str(transition_json).unwrap();
+        assert_eq!(transition.sender_name.as_deref(), Some("support"));
+        assert_eq!(transition.author.as_deref(), Some("support"));
+        assert_eq!(transition.is_admin, Some(true));
+        assert_eq!(transition.is_staff, Some(true));
     }
 
     // -----------------------------------------------------------------------

--- a/src/client.rs
+++ b/src/client.rs
@@ -9628,6 +9628,15 @@ mod tests {
         assert_eq!(transition.author.as_deref(), Some("support"));
         assert_eq!(transition.is_admin, Some(true));
         assert_eq!(transition.is_staff, Some(true));
+
+        let null_json = r#"{"id":"msg-3","senderName":null,"isAdmin":null}"#;
+        let null_message: TicketMessage = serde_json::from_str(null_json).unwrap();
+        assert_eq!(null_message.sender_name, None);
+        assert_eq!(null_message.author, None);
+        assert_eq!(null_message.is_admin, None);
+        assert_eq!(null_message.is_staff, None);
+        assert!(null_message.extra["senderName"].is_null());
+        assert!(null_message.extra["isAdmin"].is_null());
     }
 
     // -----------------------------------------------------------------------

--- a/src/types.rs
+++ b/src/types.rs
@@ -3743,7 +3743,7 @@ pub struct Ticket {
     pub extra: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TicketMessage {
     pub id: String,
@@ -3752,13 +3752,55 @@ pub struct TicketMessage {
     #[serde(default)]
     pub body: Option<String>,
     #[serde(default)]
-    pub author: Option<String>,
+    pub sender_name: Option<String>,
     #[serde(default)]
+    pub is_admin: Option<bool>,
+    #[serde(skip_serializing)]
+    pub author: Option<String>,
+    #[serde(skip_serializing)]
     pub is_staff: Option<bool>,
     #[serde(default)]
     pub created_at: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
+}
+
+impl<'de> Deserialize<'de> for TicketMessage {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct TicketMessageWire {
+            id: String,
+            #[serde(default)]
+            ticket_id: Option<String>,
+            #[serde(default)]
+            body: Option<String>,
+            #[serde(default, alias = "author")]
+            sender_name: Option<String>,
+            #[serde(default, alias = "isStaff")]
+            is_admin: Option<bool>,
+            #[serde(default)]
+            created_at: Option<String>,
+            #[serde(flatten)]
+            extra: serde_json::Value,
+        }
+
+        let wire = TicketMessageWire::deserialize(deserializer)?;
+        Ok(Self {
+            id: wire.id,
+            ticket_id: wire.ticket_id,
+            body: wire.body,
+            author: wire.sender_name.clone(),
+            sender_name: wire.sender_name,
+            is_staff: wire.is_admin,
+            is_admin: wire.is_admin,
+            created_at: wire.created_at,
+            extra: wire.extra,
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types.rs
+++ b/src/types.rs
@@ -3770,37 +3770,66 @@ impl<'de> Deserialize<'de> for TicketMessage {
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct TicketMessageWire {
-            id: String,
-            #[serde(default)]
-            ticket_id: Option<String>,
-            #[serde(default)]
-            body: Option<String>,
-            #[serde(default, alias = "author")]
-            sender_name: Option<String>,
-            #[serde(default, alias = "isStaff")]
-            is_admin: Option<bool>,
-            #[serde(default)]
-            created_at: Option<String>,
-            #[serde(flatten)]
-            extra: serde_json::Value,
+        let mut fields = serde_json::Map::deserialize(deserializer)?;
+
+        let id = fields
+            .remove("id")
+            .ok_or_else(|| <D::Error as serde::de::Error>::missing_field("id"))
+            .and_then(|value| serde_json::from_value(value).map_err(serde::de::Error::custom))?;
+        let ticket_id: Option<String> =
+            deserialize_optional_ticket_message_field(&mut fields, "ticketId")?;
+        let body: Option<String> = deserialize_optional_ticket_message_field(&mut fields, "body")?;
+        let platform_sender_name: Option<String> =
+            deserialize_optional_ticket_message_field(&mut fields, "senderName")?;
+        let legacy_author: Option<String> =
+            deserialize_optional_ticket_message_field(&mut fields, "author")?;
+        let sender_name = platform_sender_name.or(legacy_author);
+        let platform_is_admin: Option<bool> =
+            deserialize_optional_ticket_message_field(&mut fields, "isAdmin")?;
+        let legacy_is_staff: Option<bool> =
+            deserialize_optional_ticket_message_field(&mut fields, "isStaff")?;
+        let is_admin = platform_is_admin.or(legacy_is_staff);
+        let created_at: Option<String> =
+            deserialize_optional_ticket_message_field(&mut fields, "createdAt")?;
+
+        let mut extra = fields;
+        if let Some(sender_name) = &sender_name {
+            extra.insert(
+                "senderName".to_string(),
+                serde_json::Value::String(sender_name.clone()),
+            );
+        }
+        if let Some(is_admin) = is_admin {
+            extra.insert("isAdmin".to_string(), serde_json::Value::Bool(is_admin));
         }
 
-        let wire = TicketMessageWire::deserialize(deserializer)?;
         Ok(Self {
-            id: wire.id,
-            ticket_id: wire.ticket_id,
-            body: wire.body,
-            author: wire.sender_name.clone(),
-            sender_name: wire.sender_name,
-            is_staff: wire.is_admin,
-            is_admin: wire.is_admin,
-            created_at: wire.created_at,
-            extra: wire.extra,
+            id,
+            ticket_id,
+            body,
+            author: sender_name.clone(),
+            sender_name,
+            is_staff: is_admin,
+            is_admin,
+            created_at,
+            extra: serde_json::Value::Object(extra),
         })
     }
+}
+
+fn deserialize_optional_ticket_message_field<T, E>(
+    fields: &mut serde_json::Map<String, serde_json::Value>,
+    name: &str,
+) -> std::result::Result<Option<T>, E>
+where
+    T: serde::de::DeserializeOwned,
+    E: serde::de::Error,
+{
+    fields
+        .remove(name)
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(E::custom)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types.rs
+++ b/src/types.rs
@@ -3743,25 +3743,16 @@ pub struct Ticket {
     pub extra: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
 pub struct TicketMessage {
     pub id: String,
-    #[serde(default)]
     pub ticket_id: Option<String>,
-    #[serde(default)]
     pub body: Option<String>,
-    #[serde(default)]
     pub sender_name: Option<String>,
-    #[serde(default)]
     pub is_admin: Option<bool>,
-    #[serde(skip_serializing)]
     pub author: Option<String>,
-    #[serde(skip_serializing)]
     pub is_staff: Option<bool>,
-    #[serde(default)]
     pub created_at: Option<String>,
-    #[serde(flatten)]
     pub extra: serde_json::Value,
 }
 
@@ -3783,38 +3774,29 @@ impl<'de> Deserialize<'de> for TicketMessage {
             deserialize_ticket_message_field(&mut fields, "senderName")?;
         let legacy_author: Option<String> =
             deserialize_ticket_message_field(&mut fields, "author")?.0;
-        let sender_name = platform_sender_name.or(legacy_author);
+        let sender_name = if raw_sender_name.is_some() {
+            platform_sender_name
+        } else {
+            legacy_author
+        };
         let (platform_is_admin, raw_is_admin): (Option<bool>, Option<serde_json::Value>) =
             deserialize_ticket_message_field(&mut fields, "isAdmin")?;
         let legacy_is_staff: Option<bool> =
             deserialize_ticket_message_field(&mut fields, "isStaff")?.0;
-        let is_admin = platform_is_admin.or(legacy_is_staff);
+        let is_admin = if raw_is_admin.is_some() {
+            platform_is_admin
+        } else {
+            legacy_is_staff
+        };
         let created_at: Option<String> =
             deserialize_ticket_message_field(&mut fields, "createdAt")?.0;
 
         let mut extra = fields;
-        match raw_sender_name {
-            Some(value) => {
-                extra.insert("senderName".to_string(), value);
-            }
-            None => {
-                if let Some(sender_name) = &sender_name {
-                    extra.insert(
-                        "senderName".to_string(),
-                        serde_json::Value::String(sender_name.clone()),
-                    );
-                }
-            }
+        if let Some(value) = raw_sender_name {
+            extra.insert("senderName".to_string(), value);
         }
-        match raw_is_admin {
-            Some(value) => {
-                extra.insert("isAdmin".to_string(), value);
-            }
-            None => {
-                if let Some(is_admin) = is_admin {
-                    extra.insert("isAdmin".to_string(), serde_json::Value::Bool(is_admin));
-                }
-            }
+        if let Some(value) = raw_is_admin {
+            extra.insert("isAdmin".to_string(), value);
         }
 
         Ok(Self {
@@ -3828,6 +3810,41 @@ impl<'de> Deserialize<'de> for TicketMessage {
             created_at,
             extra: serde_json::Value::Object(extra),
         })
+    }
+}
+
+impl Serialize for TicketMessage {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        let mut field_count = 6;
+        if let serde_json::Value::Object(extra) = &self.extra {
+            field_count += extra
+                .keys()
+                .filter(|key| key.as_str() != "senderName" && key.as_str() != "isAdmin")
+                .count();
+        }
+
+        let mut map = serializer.serialize_map(Some(field_count))?;
+        map.serialize_entry("id", &self.id)?;
+        map.serialize_entry("ticketId", &self.ticket_id)?;
+        map.serialize_entry("body", &self.body)?;
+        map.serialize_entry("senderName", &self.sender_name)?;
+        map.serialize_entry("isAdmin", &self.is_admin)?;
+        map.serialize_entry("createdAt", &self.created_at)?;
+
+        if let serde_json::Value::Object(extra) = &self.extra {
+            for (key, value) in extra {
+                if key != "senderName" && key != "isAdmin" {
+                    map.serialize_entry(key, value)?;
+                }
+            }
+        }
+
+        map.end()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3777,30 +3777,44 @@ impl<'de> Deserialize<'de> for TicketMessage {
             .ok_or_else(|| <D::Error as serde::de::Error>::missing_field("id"))
             .and_then(|value| serde_json::from_value(value).map_err(serde::de::Error::custom))?;
         let ticket_id: Option<String> =
-            deserialize_optional_ticket_message_field(&mut fields, "ticketId")?;
-        let body: Option<String> = deserialize_optional_ticket_message_field(&mut fields, "body")?;
-        let platform_sender_name: Option<String> =
-            deserialize_optional_ticket_message_field(&mut fields, "senderName")?;
+            deserialize_ticket_message_field(&mut fields, "ticketId")?.0;
+        let body: Option<String> = deserialize_ticket_message_field(&mut fields, "body")?.0;
+        let (platform_sender_name, raw_sender_name): (Option<String>, Option<serde_json::Value>) =
+            deserialize_ticket_message_field(&mut fields, "senderName")?;
         let legacy_author: Option<String> =
-            deserialize_optional_ticket_message_field(&mut fields, "author")?;
+            deserialize_ticket_message_field(&mut fields, "author")?.0;
         let sender_name = platform_sender_name.or(legacy_author);
-        let platform_is_admin: Option<bool> =
-            deserialize_optional_ticket_message_field(&mut fields, "isAdmin")?;
+        let (platform_is_admin, raw_is_admin): (Option<bool>, Option<serde_json::Value>) =
+            deserialize_ticket_message_field(&mut fields, "isAdmin")?;
         let legacy_is_staff: Option<bool> =
-            deserialize_optional_ticket_message_field(&mut fields, "isStaff")?;
+            deserialize_ticket_message_field(&mut fields, "isStaff")?.0;
         let is_admin = platform_is_admin.or(legacy_is_staff);
         let created_at: Option<String> =
-            deserialize_optional_ticket_message_field(&mut fields, "createdAt")?;
+            deserialize_ticket_message_field(&mut fields, "createdAt")?.0;
 
         let mut extra = fields;
-        if let Some(sender_name) = &sender_name {
-            extra.insert(
-                "senderName".to_string(),
-                serde_json::Value::String(sender_name.clone()),
-            );
+        match raw_sender_name {
+            Some(value) => {
+                extra.insert("senderName".to_string(), value);
+            }
+            None => {
+                if let Some(sender_name) = &sender_name {
+                    extra.insert(
+                        "senderName".to_string(),
+                        serde_json::Value::String(sender_name.clone()),
+                    );
+                }
+            }
         }
-        if let Some(is_admin) = is_admin {
-            extra.insert("isAdmin".to_string(), serde_json::Value::Bool(is_admin));
+        match raw_is_admin {
+            Some(value) => {
+                extra.insert("isAdmin".to_string(), value);
+            }
+            None => {
+                if let Some(is_admin) = is_admin {
+                    extra.insert("isAdmin".to_string(), serde_json::Value::Bool(is_admin));
+                }
+            }
         }
 
         Ok(Self {
@@ -3817,19 +3831,21 @@ impl<'de> Deserialize<'de> for TicketMessage {
     }
 }
 
-fn deserialize_optional_ticket_message_field<T, E>(
+fn deserialize_ticket_message_field<T, E>(
     fields: &mut serde_json::Map<String, serde_json::Value>,
     name: &str,
-) -> std::result::Result<Option<T>, E>
+) -> std::result::Result<(Option<T>, Option<serde_json::Value>), E>
 where
     T: serde::de::DeserializeOwned,
     E: serde::de::Error,
 {
-    fields
-        .remove(name)
-        .map(serde_json::from_value)
-        .transpose()
-        .map_err(E::custom)
+    match fields.remove(name) {
+        Some(value) if value.is_null() => Ok((None, Some(value))),
+        Some(value) => serde_json::from_value(value.clone())
+            .map(|decoded| (Some(decoded), Some(value)))
+            .map_err(E::custom),
+        None => Ok((None, None)),
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- map platform `senderName` / `isAdmin` into typed Rust SDK `TicketMessage` fields
- keep `author` / `is_staff` populated as deserialization aliases for compatibility
- preserve raw platform `senderName` / `isAdmin` values in `extra`, including explicit nulls
- update the ticket message fixture to match the platform wire shape

Fixes #313

## Verification
- `node .gitnexus/run.cjs impact TicketMessage --repo polyforge-sdk-rust --direction upstream --include-tests` -> LOW, 0 direct callers, 0 affected processes, 0 affected modules
- `node .gitnexus/run.cjs impact test_ticket_message_deserializes --repo polyforge-sdk-rust --direction upstream --include-tests` -> LOW, 0 direct callers, 0 affected processes, 0 affected modules
- `git diff --check -- src/client.rs src/types.rs`
- `cargo test ticket --lib` -> 6 passed, with one pre-existing dead-code warning on `test_create_conditional_order_params_serializes_camelcase`

## Notes
- The local GitNexus CLI exposes `detect_changes` only through the eval-server/MCP layer. That route could not uniquely select this worktree because several indexed `polyforge-sdk-rust` entries share the same display name and the generated collision id is not resolvable through the lowercasing resolver. I verified scope with `git diff --check`, `git diff --name-only`, and the targeted impact checks above.
- Local `cargo fmt` reports formatting drift in unrelated existing `src/client.rs` hunks outside this PR diff. I left those unrelated formatter changes out of this PR.