### PR TITLE
feat: add websocket gateway client

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ Server messages are parsed into typed envelopes for `AUTH_OK`, `PONG`,
 `PRICE_UPDATE`, `WHALE_TRADE`, `NEWS_SIGNAL`, and `MARKET_SETTLEMENT`; unknown
 broadcast event types are preserved as `WsServerMessage::Broadcast`.
 
+`connect_websocket` is also available for API-key based gateway connections.
+It sends the key as the gateway's `pf_token` cookie by default; use
+`connect_websocket_with_auth_mode(polyforge::WebSocketAuthMode::Query)` only
+when query-string token compatibility is required.
+
 ### Portfolio & Orders
 
 Trading write methods automatically attach a fresh 32-character `Idempotency-Key`

--- a/README.md
+++ b/README.md
@@ -249,8 +249,9 @@ broadcast event types are preserved as `WsServerMessage::Broadcast`.
 
 `connect_websocket` is also available for API-key based gateway connections.
 It sends the key as the gateway's `pf_token` cookie by default; use
-`connect_websocket_with_auth_mode(polyforge::WebSocketAuthMode::Query)` only
-when query-string token compatibility is required.
+`connect_websocket_with_auth_mode(polyforge::WebSocketAuthMode::QueryToken(...))`
+only with a short-lived gateway token when query-string token compatibility is
+required.
 
 ### Portfolio & Orders
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,6 +42,10 @@ const MAX_GDPR_EXPORT_SIZE: usize = 500 * 1024 * 1024; // 500 MiB
 
 const IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
 const MAX_WEBSOCKET_SUBSCRIPTIONS: usize = 200;
+#[cfg(not(test))]
+const WEBSOCKET_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(test)]
+const WEBSOCKET_HANDSHAKE_TIMEOUT: Duration = Duration::from_millis(100);
 
 // ---------------------------------------------------------------------------
 // PolyforgeWebSocketClient — async client for the native /ws gateway
@@ -228,7 +232,7 @@ impl StrategyEventStream {
                         return Some(
                             serde_json::from_str::<StrategyEvent>(raw)
                                 .map_err(PolyforgeError::from),
-                       );
+                        );
                     }
                 }
                 // Skip comment / heartbeat lines and loop
@@ -1513,9 +1517,7 @@ impl PolyforgeClient {
     /// Get strategy design patterns for AI / tooling discovery.
     ///
     /// `GET /api/v1/strategies/design-patterns`
-    pub async fn get_strategy_design_patterns_typed(
-        &self,
-    ) -> Result<StrategyDesignPatterns> {
+    pub async fn get_strategy_design_patterns_typed(&self) -> Result<StrategyDesignPatterns> {
         self.get_with_optional_auth("/api/v1/strategies/design-patterns")
             .await
     }
@@ -2224,8 +2226,7 @@ impl PolyforgeClient {
         params: &BulkCancelParams,
     ) -> Result<BulkCancelResponse> {
         let body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
-        self.post_idempotent("/api/v1/orders/bulk", &body)
-            .await
+        self.post_idempotent("/api/v1/orders/bulk", &body).await
     }
 
     /// Close an open prediction-market position (partial or sweep).
@@ -2822,10 +2823,7 @@ impl PolyforgeClient {
     /// to EIP-55 checksummed format.
     fn create_copy_config_body(params: &CreateCopyConfigParams) -> Result<serde_json::Value> {
         let mut body = serde_json::to_value(params).map_err(PolyforgeError::from)?;
-        if let Some(raw) = body
-            .get("targetWallet")
-            .and_then(serde_json::Value::as_str)
-        {
+        if let Some(raw) = body.get("targetWallet").and_then(serde_json::Value::as_str) {
             body["targetWallet"] = serde_json::Value::String(checksum_address(raw)?);
         }
         Ok(body)
@@ -3486,7 +3484,18 @@ impl PolyforgeClient {
                 })?,
             );
         }
-        let (stream, _) = connect_async(request).await?;
+        let (stream, _) = tokio::time::timeout(WEBSOCKET_HANDSHAKE_TIMEOUT, connect_async(request))
+            .await
+            .map_err(|_| PolyforgeError::Api {
+                status: 0,
+                code: "WEBSOCKET_HANDSHAKE_TIMEOUT".into(),
+                message: format!(
+                    "WebSocket handshake timed out after {:?}",
+                    WEBSOCKET_HANDSHAKE_TIMEOUT
+                ),
+                request_id: None,
+                suggestion: Some("Retry the connection or check gateway availability".into()),
+            })??;
         Ok(PolyforgeWebSocketClient { stream })
     }
 
@@ -4622,6 +4631,39 @@ mod tests {
             server.await.unwrap(),
             r#"{"type":"SUBSCRIBE_PRICES","tokenIds":["token-a","token-b"]}"#
         );
+    }
+
+    #[tokio::test]
+    async fn test_connect_websocket_times_out_when_handshake_stalls() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+
+        let client =
+            PolyforgeClient::with_url("jwt-token", format!("http://{addr}/api/v1")).unwrap();
+        let result = tokio::time::timeout(Duration::from_millis(500), client.connect_websocket())
+            .await
+            .expect("websocket connection attempt should not hang indefinitely");
+
+        match result {
+            Err(PolyforgeError::Api {
+                code,
+                message,
+                status,
+                ..
+            }) => {
+                assert_eq!(status, 0);
+                assert_eq!(code, "WEBSOCKET_HANDSHAKE_TIMEOUT");
+                assert!(message.contains("timed out"));
+            }
+            other => panic!("expected websocket handshake timeout error, got {other:?}"),
+        }
+
+        server.abort();
     }
 
     #[tokio::test]
@@ -8139,7 +8181,10 @@ mod tests {
 
         // Verify known EIP-55 address: 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed
         let known = "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed";
-        assert_eq!(checksum_address(known).unwrap(), "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+        assert_eq!(
+            checksum_address(known).unwrap(),
+            "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
+        );
 
         // Already checksummed address stays unchanged (idempotent)
         let already = "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed";

--- a/src/client.rs
+++ b/src/client.rs
@@ -141,6 +141,7 @@ impl PolyforgeWebSocketClient {
 
     /// Subscribe to whale trade events, optionally filtering by minimum size.
     pub async fn subscribe_whales(&mut self, min_size: Option<f64>) -> Result<()> {
+        let min_size = validate_websocket_min_size(min_size)?;
         self.send(WebSocketClientMessage::SubscribeWhales { min_size })
             .await
     }
@@ -191,6 +192,17 @@ fn normalize_websocket_id(name: &str, id: &str) -> Result<String> {
         )));
     }
     Ok(id.to_string())
+}
+
+fn validate_websocket_min_size(min_size: Option<f64>) -> Result<Option<f64>> {
+    if let Some(value) = min_size {
+        if !value.is_finite() {
+            return Err(PolyforgeError::Validation(
+                "min_size must be finite when subscribing to whale trades".into(),
+            ));
+        }
+    }
+    Ok(min_size)
 }
 
 /// An open SSE connection to a strategy's execution event stream.
@@ -4566,6 +4578,23 @@ mod tests {
                 serde_json::json!({"type":"PING"}),
             ]
         );
+    }
+
+    #[test]
+    fn test_websocket_subscribe_whales_rejects_nonfinite_thresholds_before_serialization() {
+        assert!(matches!(
+            validate_websocket_min_size(Some(f64::NAN)),
+            Err(PolyforgeError::Validation(_))
+        ));
+        assert!(matches!(
+            validate_websocket_min_size(Some(f64::INFINITY)),
+            Err(PolyforgeError::Validation(_))
+        ));
+        assert_eq!(
+            validate_websocket_min_size(Some(1_000.0)).unwrap(),
+            Some(1_000.0)
+        );
+        assert_eq!(validate_websocket_min_size(None).unwrap(), None);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -139,9 +139,10 @@ impl PolyforgeWebSocketClient {
             .await
     }
 
-    /// Subscribe to whale trade events.
-    pub async fn subscribe_whales(&mut self) -> Result<()> {
-        self.send(WebSocketClientMessage::SubscribeWhales).await
+    /// Subscribe to whale trade events, optionally filtering by minimum size.
+    pub async fn subscribe_whales(&mut self, min_size: Option<f64>) -> Result<()> {
+        self.send(WebSocketClientMessage::SubscribeWhales { min_size })
+            .await
     }
 
     /// Unsubscribe from whale trade events.
@@ -668,7 +669,7 @@ impl PolyforgeClient {
         crate::GatewayWsClient::connect(url, options.reconnect).await
     }
 
-    fn native_websocket_url(&self, auth_mode: WebSocketAuthMode) -> Result<Url> {
+    fn native_websocket_url(&self, auth_mode: &WebSocketAuthMode) -> Result<Url> {
         let mut url = Url::parse(&self.base_url)
             .map_err(|e| PolyforgeError::Validation(format!("Malformed base URL: {e}")))?;
         match url.scheme() {
@@ -687,9 +688,13 @@ impl PolyforgeClient {
         url.set_path("/ws");
         url.set_query(None);
         url.set_fragment(None);
-        if auth_mode == WebSocketAuthMode::Query {
-            url.query_pairs_mut()
-                .append_pair("token", self.api_key.expose_secret());
+        if let WebSocketAuthMode::QueryToken(token) = auth_mode {
+            if token.trim().is_empty() {
+                return Err(PolyforgeError::Validation(
+                    "WebSocket query auth requires a non-empty gateway token".into(),
+                ));
+            }
+            url.query_pairs_mut().append_pair("token", token);
         }
         Ok(url)
     }
@@ -3456,10 +3461,9 @@ impl PolyforgeClient {
     /// Open an authenticated connection to the native `/ws` gateway.
     ///
     /// The default auth mode sends the API token as `Cookie: pf_token=...`,
-    /// matching the non-browser gateway path. Use
-    /// [`connect_websocket_with_auth_mode`](Self::connect_websocket_with_auth_mode)
-    /// with [`WebSocketAuthMode::Query`] for compatibility with clients that
-    /// require query-string token auth.
+    /// matching the non-browser gateway path. If query-string compatibility is
+    /// required, pass a short-lived gateway token with
+    /// [`WebSocketAuthMode::QueryToken`].
     pub async fn connect_websocket(&self) -> Result<PolyforgeWebSocketClient> {
         self.connect_websocket_with_auth_mode(WebSocketAuthMode::Cookie)
             .await
@@ -3471,7 +3475,7 @@ impl PolyforgeClient {
         &self,
         auth_mode: WebSocketAuthMode,
     ) -> Result<PolyforgeWebSocketClient> {
-        let url = self.native_websocket_url(auth_mode)?;
+        let url = self.native_websocket_url(&auth_mode)?;
         let mut request = url.as_str().into_client_request()?;
         if auth_mode == WebSocketAuthMode::Cookie {
             let cookie = format!("pf_token={}", self.api_key.expose_secret());
@@ -4498,27 +4502,31 @@ mod tests {
             PolyforgeClient::with_url("jwt-token", "https://api.polyforge.app/api/v1").unwrap();
         assert_eq!(
             client
-                .native_websocket_url(WebSocketAuthMode::Cookie)
+                .native_websocket_url(&WebSocketAuthMode::Cookie)
                 .unwrap()
                 .as_str(),
             "wss://api.polyforge.app/ws"
         );
         assert_eq!(
             client
-                .native_websocket_url(WebSocketAuthMode::Query)
+                .native_websocket_url(&WebSocketAuthMode::QueryToken("gateway-jwt".into()))
                 .unwrap()
                 .as_str(),
-            "wss://api.polyforge.app/ws?token=jwt-token"
+            "wss://api.polyforge.app/ws?token=gateway-jwt"
         );
 
         let local = PolyforgeClient::with_url("jwt token", "http://localhost:3002").unwrap();
         assert_eq!(
             local
-                .native_websocket_url(WebSocketAuthMode::Query)
+                .native_websocket_url(&WebSocketAuthMode::QueryToken("gateway token".into()))
                 .unwrap()
                 .as_str(),
-            "ws://localhost:3002/ws?token=jwt+token"
+            "ws://localhost:3002/ws?token=gateway+token"
         );
+        assert!(matches!(
+            client.native_websocket_url(&WebSocketAuthMode::QueryToken("  ".into())),
+            Err(PolyforgeError::Validation(_))
+        ));
     }
 
     #[test]
@@ -4530,7 +4538,10 @@ mod tests {
             WebSocketClientMessage::UnsubscribePrices {
                 token_ids: vec!["token-a".into()],
             },
-            WebSocketClientMessage::SubscribeWhales,
+            WebSocketClientMessage::SubscribeWhales {
+                min_size: Some(1_000.0),
+            },
+            WebSocketClientMessage::SubscribeWhales { min_size: None },
             WebSocketClientMessage::UnsubscribeWhales,
             WebSocketClientMessage::SubscribeStrategy {
                 strategy_id: "strategy-a".into(),
@@ -4548,6 +4559,7 @@ mod tests {
             vec![
                 serde_json::json!({"type":"SUBSCRIBE_PRICES","tokenIds":["token-a","token-b"]}),
                 serde_json::json!({"type":"UNSUBSCRIBE_PRICES","tokenIds":["token-a"]}),
+                serde_json::json!({"type":"SUBSCRIBE_WHALES","minSize":1000.0}),
                 serde_json::json!({"type":"SUBSCRIBE_WHALES"}),
                 serde_json::json!({"type":"UNSUBSCRIBE_WHALES"}),
                 serde_json::json!({"type":"SUBSCRIBE_STRATEGY","strategyId":"strategy-a"}),
@@ -4573,17 +4585,21 @@ mod tests {
         let broadcast: WebSocketEvent = serde_json::from_value(serde_json::json!({
             "type": "NOTIFICATION",
             "data": {"title": "Broadcast"},
-            "timestamp": 13
+            "timestamp": "2026-06-30T06:52:49Z"
         }))
         .unwrap();
 
         assert_eq!(price.event_type, "PRICE_UPDATE");
         assert_eq!(price.data["tokenId"], "token-a");
-        assert_eq!(price.timestamp, Some(11));
+        assert_eq!(price.timestamp, Some(serde_json::json!(11)));
         assert_eq!(whale.event_type, "WHALE_TRADE");
         assert_eq!(whale.data["walletAddress"], "0xabc");
         assert_eq!(broadcast.event_type, "NOTIFICATION");
         assert_eq!(broadcast.data["title"], "Broadcast");
+        assert_eq!(
+            broadcast.timestamp,
+            Some(serde_json::json!("2026-06-30T06:52:49Z"))
+        );
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,13 @@
+use futures_util::{SinkExt, StreamExt};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use secrecy::{ExposeSecret, SecretBox};
 use serde_json::json;
 use sha3::{Digest, Keccak256};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::header::COOKIE;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 use url::Url;
 use urlencoding::encode;
 
@@ -35,6 +41,152 @@ const MAX_RESPONSE_BODY_SIZE: usize = 1_048_576; // 1 MiB
 const MAX_GDPR_EXPORT_SIZE: usize = 500 * 1024 * 1024; // 500 MiB
 
 const IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
+const MAX_WEBSOCKET_SUBSCRIPTIONS: usize = 200;
+
+// ---------------------------------------------------------------------------
+// PolyforgeWebSocketClient — async client for the native /ws gateway
+// ---------------------------------------------------------------------------
+
+/// An open WebSocket connection to Polyforge's native `/ws` gateway.
+///
+/// Use this client for live price updates, whale trades, strategy events, and
+/// broadcast notifications. For strategy-only SSE streams, use
+/// [`PolyforgeClient::watch_strategy`].
+pub struct PolyforgeWebSocketClient {
+    stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+}
+
+impl std::fmt::Debug for PolyforgeWebSocketClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PolyforgeWebSocketClient").finish()
+    }
+}
+
+impl PolyforgeWebSocketClient {
+    /// Send a raw gateway message.
+    pub async fn send(&mut self, message: WebSocketClientMessage) -> Result<()> {
+        let payload = serde_json::to_string(&message)?;
+        self.stream.send(Message::Text(payload.into())).await?;
+        Ok(())
+    }
+
+    /// Receive the next gateway event.
+    ///
+    /// Returns `None` when the server closes the connection.
+    pub async fn next(&mut self) -> Option<Result<WebSocketEvent>> {
+        loop {
+            let message = self.stream.next().await?;
+            match message {
+                Ok(Message::Text(payload)) => {
+                    return Some(
+                        serde_json::from_str::<WebSocketEvent>(&payload).map_err(Into::into),
+                    );
+                }
+                Ok(Message::Binary(payload)) => {
+                    let parsed = String::from_utf8(payload.to_vec()).map_err(|e| {
+                        PolyforgeError::Validation(format!(
+                            "Invalid UTF-8 in WebSocket message: {e}"
+                        ))
+                    });
+                    return Some(parsed.and_then(|text| {
+                        serde_json::from_str::<WebSocketEvent>(&text).map_err(Into::into)
+                    }));
+                }
+                Ok(Message::Close(_)) => return None,
+                Ok(Message::Ping(_)) | Ok(Message::Pong(_)) | Ok(Message::Frame(_)) => continue,
+                Err(e) => return Some(Err(PolyforgeError::from(e))),
+            }
+        }
+    }
+
+    /// Subscribe to live price updates for one or more token IDs.
+    pub async fn subscribe_prices<I, S>(&mut self, token_ids: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let token_ids = normalize_websocket_ids("tokenIds", token_ids)?;
+        self.send(WebSocketClientMessage::SubscribePrices { token_ids })
+            .await
+    }
+
+    /// Unsubscribe from live price updates for one or more token IDs.
+    pub async fn unsubscribe_prices<I, S>(&mut self, token_ids: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let token_ids = normalize_websocket_ids("tokenIds", token_ids)?;
+        self.send(WebSocketClientMessage::UnsubscribePrices { token_ids })
+            .await
+    }
+
+    /// Subscribe to live strategy events for a strategy ID.
+    pub async fn subscribe_strategy(&mut self, strategy_id: &str) -> Result<()> {
+        let strategy_id = normalize_websocket_id("strategyId", strategy_id)?;
+        self.send(WebSocketClientMessage::SubscribeStrategy { strategy_id })
+            .await
+    }
+
+    /// Unsubscribe from live strategy events for a strategy ID.
+    pub async fn unsubscribe_strategy(&mut self, strategy_id: &str) -> Result<()> {
+        let strategy_id = normalize_websocket_id("strategyId", strategy_id)?;
+        self.send(WebSocketClientMessage::UnsubscribeStrategy { strategy_id })
+            .await
+    }
+
+    /// Subscribe to whale trade events.
+    pub async fn subscribe_whales(&mut self) -> Result<()> {
+        self.send(WebSocketClientMessage::SubscribeWhales).await
+    }
+
+    /// Unsubscribe from whale trade events.
+    pub async fn unsubscribe_whales(&mut self) -> Result<()> {
+        self.send(WebSocketClientMessage::UnsubscribeWhales).await
+    }
+
+    /// Send a gateway ping.
+    pub async fn ping(&mut self) -> Result<()> {
+        self.send(WebSocketClientMessage::Ping).await
+    }
+
+    /// Close the WebSocket connection.
+    pub async fn close(&mut self) -> Result<()> {
+        self.stream.close(None).await?;
+        Ok(())
+    }
+}
+
+fn normalize_websocket_ids<I, S>(name: &str, ids: I) -> Result<Vec<String>>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let ids: Vec<String> = ids.into_iter().map(Into::into).collect();
+    if ids.is_empty() {
+        return Err(PolyforgeError::Validation(format!(
+            "{name} must contain at least one id"
+        )));
+    }
+    if ids.len() > MAX_WEBSOCKET_SUBSCRIPTIONS {
+        return Err(PolyforgeError::Validation(format!(
+            "{name} can contain at most {MAX_WEBSOCKET_SUBSCRIPTIONS} ids"
+        )));
+    }
+    for id in &ids {
+        normalize_websocket_id(name, id)?;
+    }
+    Ok(ids)
+}
+
+fn normalize_websocket_id(name: &str, id: &str) -> Result<String> {
+    if id.is_empty() || id.len() > 128 {
+        return Err(PolyforgeError::Validation(format!(
+            "{name} must be a non-empty string up to 128 characters"
+        )));
+    }
+    Ok(id.to_string())
+}
 
 /// An open SSE connection to a strategy's execution event stream.
 ///
@@ -510,6 +662,32 @@ impl PolyforgeClient {
     ) -> Result<crate::GatewayWsClient> {
         let url = self.websocket_url(&options)?;
         crate::GatewayWsClient::connect(url, options.reconnect).await
+    }
+
+    fn native_websocket_url(&self, auth_mode: WebSocketAuthMode) -> Result<Url> {
+        let mut url = Url::parse(&self.base_url)
+            .map_err(|e| PolyforgeError::Validation(format!("Malformed base URL: {e}")))?;
+        match url.scheme() {
+            "https" => url
+                .set_scheme("wss")
+                .map_err(|_| PolyforgeError::Validation("Unable to build WebSocket URL".into()))?,
+            "http" => url
+                .set_scheme("ws")
+                .map_err(|_| PolyforgeError::Validation("Unable to build WebSocket URL".into()))?,
+            other => {
+                return Err(PolyforgeError::Validation(format!(
+                    "Unsupported URL scheme \"{other}\"; expected http or https"
+                )));
+            }
+        }
+        url.set_path("/ws");
+        url.set_query(None);
+        url.set_fragment(None);
+        if auth_mode == WebSocketAuthMode::Query {
+            url.query_pairs_mut()
+                .append_pair("token", self.api_key.expose_secret());
+        }
+        Ok(url)
     }
 
     fn auth_header(&self) -> Result<HeaderValue> {
@@ -3273,6 +3451,45 @@ impl PolyforgeClient {
         })
     }
 
+    // -----------------------------------------------------------------------
+    // Native WebSocket Gateway
+    // -----------------------------------------------------------------------
+
+    /// Open an authenticated connection to the native `/ws` gateway.
+    ///
+    /// The default auth mode sends the API token as `Cookie: pf_token=...`,
+    /// matching the non-browser gateway path. Use
+    /// [`connect_websocket_with_auth_mode`](Self::connect_websocket_with_auth_mode)
+    /// with [`WebSocketAuthMode::Query`] for compatibility with clients that
+    /// require query-string token auth.
+    pub async fn connect_websocket(&self) -> Result<PolyforgeWebSocketClient> {
+        self.connect_websocket_with_auth_mode(WebSocketAuthMode::Cookie)
+            .await
+    }
+
+    /// Open an authenticated connection to the native `/ws` gateway using an
+    /// explicit auth mode.
+    pub async fn connect_websocket_with_auth_mode(
+        &self,
+        auth_mode: WebSocketAuthMode,
+    ) -> Result<PolyforgeWebSocketClient> {
+        let url = self.native_websocket_url(auth_mode)?;
+        let mut request = url.as_str().into_client_request()?;
+        if auth_mode == WebSocketAuthMode::Cookie {
+            let cookie = format!("pf_token={}", self.api_key.expose_secret());
+            request.headers_mut().insert(
+                COOKIE,
+                HeaderValue::from_str(&cookie).map_err(|_| {
+                    PolyforgeError::Validation(
+                        "API key contains invalid HTTP cookie characters".into(),
+                    )
+                })?,
+            );
+        }
+        let (stream, _) = connect_async(request).await?;
+        Ok(PolyforgeWebSocketClient { stream })
+    }
+
     async fn put<T: serde::de::DeserializeOwned>(
         &self,
         path: &str,
@@ -4264,6 +4481,147 @@ mod tests {
         .await;
 
         assert_generated_idempotency_key(&request);
+    }
+
+    #[test]
+    fn test_websocket_url_builds_gateway_path_and_supports_query_auth() {
+        let client =
+            PolyforgeClient::with_url("jwt-token", "https://api.polyforge.app/api/v1").unwrap();
+        assert_eq!(
+            client
+                .native_websocket_url(WebSocketAuthMode::Cookie)
+                .unwrap()
+                .as_str(),
+            "wss://api.polyforge.app/ws"
+        );
+        assert_eq!(
+            client
+                .native_websocket_url(WebSocketAuthMode::Query)
+                .unwrap()
+                .as_str(),
+            "wss://api.polyforge.app/ws?token=jwt-token"
+        );
+
+        let local = PolyforgeClient::with_url("jwt token", "http://localhost:3002").unwrap();
+        assert_eq!(
+            local
+                .native_websocket_url(WebSocketAuthMode::Query)
+                .unwrap()
+                .as_str(),
+            "ws://localhost:3002/ws?token=jwt+token"
+        );
+    }
+
+    #[test]
+    fn test_websocket_client_messages_serialize_to_gateway_protocol() {
+        let messages = vec![
+            WebSocketClientMessage::SubscribePrices {
+                token_ids: vec!["token-a".into(), "token-b".into()],
+            },
+            WebSocketClientMessage::UnsubscribePrices {
+                token_ids: vec!["token-a".into()],
+            },
+            WebSocketClientMessage::SubscribeWhales,
+            WebSocketClientMessage::UnsubscribeWhales,
+            WebSocketClientMessage::SubscribeStrategy {
+                strategy_id: "strategy-a".into(),
+            },
+            WebSocketClientMessage::Ping,
+        ];
+
+        let serialized: Vec<serde_json::Value> = messages
+            .into_iter()
+            .map(|message| serde_json::to_value(message).unwrap())
+            .collect();
+
+        assert_eq!(
+            serialized,
+            vec![
+                serde_json::json!({"type":"SUBSCRIBE_PRICES","tokenIds":["token-a","token-b"]}),
+                serde_json::json!({"type":"UNSUBSCRIBE_PRICES","tokenIds":["token-a"]}),
+                serde_json::json!({"type":"SUBSCRIBE_WHALES"}),
+                serde_json::json!({"type":"UNSUBSCRIBE_WHALES"}),
+                serde_json::json!({"type":"SUBSCRIBE_STRATEGY","strategyId":"strategy-a"}),
+                serde_json::json!({"type":"PING"}),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_websocket_events_decode_price_whale_and_broadcast_payloads() {
+        let price: WebSocketEvent = serde_json::from_value(serde_json::json!({
+            "type": "PRICE_UPDATE",
+            "data": {"tokenId": "token-a", "price": 0.42},
+            "timestamp": 11
+        }))
+        .unwrap();
+        let whale: WebSocketEvent = serde_json::from_value(serde_json::json!({
+            "type": "WHALE_TRADE",
+            "data": {"walletAddress": "0xabc"},
+            "timestamp": 12
+        }))
+        .unwrap();
+        let broadcast: WebSocketEvent = serde_json::from_value(serde_json::json!({
+            "type": "NOTIFICATION",
+            "data": {"title": "Broadcast"},
+            "timestamp": 13
+        }))
+        .unwrap();
+
+        assert_eq!(price.event_type, "PRICE_UPDATE");
+        assert_eq!(price.data["tokenId"], "token-a");
+        assert_eq!(price.timestamp, Some(11));
+        assert_eq!(whale.event_type, "WHALE_TRADE");
+        assert_eq!(whale.data["walletAddress"], "0xabc");
+        assert_eq!(broadcast.event_type, "NOTIFICATION");
+        assert_eq!(broadcast.data["title"], "Broadcast");
+    }
+
+    #[tokio::test]
+    async fn test_connect_websocket_uses_cookie_auth_and_sends_subscriptions() {
+        use futures_util::StreamExt;
+        use std::sync::{Arc, Mutex};
+        use tokio_tungstenite::accept_hdr_async;
+        use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+        use tokio_tungstenite::tungstenite::Message;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let captured_cookie = Arc::new(Mutex::new(None::<String>));
+        let server_cookie = Arc::clone(&captured_cookie);
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_hdr_async(stream, |req: &Request, resp: Response| {
+                let cookie = req
+                    .headers()
+                    .get("cookie")
+                    .and_then(|value| value.to_str().ok())
+                    .map(String::from);
+                *server_cookie.lock().unwrap() = cookie;
+                Ok(resp)
+            })
+            .await
+            .unwrap();
+            match ws.next().await.unwrap().unwrap() {
+                Message::Text(payload) => payload.to_string(),
+                other => panic!("expected text websocket message, got {other:?}"),
+            }
+        });
+
+        let client =
+            PolyforgeClient::with_url("jwt-token", format!("http://{addr}/api/v1")).unwrap();
+        let mut ws = client.connect_websocket().await.unwrap();
+        ws.subscribe_prices(["token-a", "token-b"]).await.unwrap();
+
+        assert_eq!(
+            captured_cookie.lock().unwrap().as_deref(),
+            Some("pf_token=jwt-token")
+        );
+        assert_eq!(
+            server.await.unwrap(),
+            r#"{"type":"SUBSCRIBE_PRICES","tokenIds":["token-a","token-b"]}"#
+        );
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod errors;
 pub mod types;
 pub mod ws;
 
-pub use client::{PolyforgeClient, StrategyEventStream};
+pub use client::{PolyforgeClient, PolyforgeWebSocketClient, StrategyEventStream};
 pub use errors::{PolyforgeError, Result};
 pub use types::*;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2927,6 +2927,83 @@ pub const KNOWN_STRATEGY_EVENT_TYPES: &[&str] = &[
 ];
 
 // ---------------------------------------------------------------------------
+// WebSocket Gateway Events
+// ---------------------------------------------------------------------------
+
+/// Authentication mode for the native `/ws` gateway.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebSocketAuthMode {
+    /// Send the API token as `Cookie: pf_token=...`.
+    Cookie,
+    /// Send the API token as `?token=...` for compatibility with older clients.
+    Query,
+}
+
+/// A client-to-server message for the native `/ws` gateway.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum WebSocketClientMessage {
+    #[serde(rename = "PING")]
+    Ping,
+    #[serde(rename = "SUBSCRIBE_PRICES")]
+    SubscribePrices {
+        #[serde(rename = "tokenIds")]
+        token_ids: Vec<String>,
+    },
+    #[serde(rename = "UNSUBSCRIBE_PRICES")]
+    UnsubscribePrices {
+        #[serde(rename = "tokenIds")]
+        token_ids: Vec<String>,
+    },
+    #[serde(rename = "SUBSCRIBE_STRATEGY")]
+    SubscribeStrategy {
+        #[serde(rename = "strategyId")]
+        strategy_id: String,
+    },
+    #[serde(rename = "UNSUBSCRIBE_STRATEGY")]
+    UnsubscribeStrategy {
+        #[serde(rename = "strategyId")]
+        strategy_id: String,
+    },
+    #[serde(rename = "SUBSCRIBE_WHALES")]
+    SubscribeWhales,
+    #[serde(rename = "UNSUBSCRIBE_WHALES")]
+    UnsubscribeWhales,
+}
+
+/// A server-to-client event from the native `/ws` gateway.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WebSocketEvent {
+    /// Event type identifier such as `PRICE_UPDATE`, `WHALE_TRADE`, or `NOTIFICATION`.
+    #[serde(rename = "type")]
+    pub event_type: String,
+    /// Event-specific payload.
+    #[serde(default)]
+    pub data: serde_json::Value,
+    /// Unix millisecond timestamp when provided by the gateway.
+    #[serde(default)]
+    pub timestamp: Option<u64>,
+    /// Additional gateway fields preserved for forward compatibility.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Known native WebSocket gateway event types.
+///
+/// The gateway may emit additional event types; clients should handle unknown
+/// `WebSocketEvent::event_type` values gracefully.
+pub const KNOWN_WEBSOCKET_EVENT_TYPES: &[&str] = &[
+    "AUTH_OK",
+    "PONG",
+    "PRICE_UPDATE",
+    "WHALE_TRADE",
+    "NEWS_SIGNAL",
+    "NOTIFICATION",
+    "MARKET_SETTLEMENT",
+    "ERROR",
+];
+
+// ---------------------------------------------------------------------------
 // Cross-Venue Arbitrage (POLA-782)
 // ---------------------------------------------------------------------------
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2931,12 +2931,12 @@ pub const KNOWN_STRATEGY_EVENT_TYPES: &[&str] = &[
 // ---------------------------------------------------------------------------
 
 /// Authentication mode for the native `/ws` gateway.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WebSocketAuthMode {
     /// Send the API token as `Cookie: pf_token=...`.
     Cookie,
-    /// Send the API token as `?token=...` for compatibility with older clients.
-    Query,
+    /// Send an explicit short-lived gateway token as `?token=...`.
+    QueryToken(String),
 }
 
 /// A client-to-server message for the native `/ws` gateway.
@@ -2966,7 +2966,10 @@ pub enum WebSocketClientMessage {
         strategy_id: String,
     },
     #[serde(rename = "SUBSCRIBE_WHALES")]
-    SubscribeWhales,
+    SubscribeWhales {
+        #[serde(rename = "minSize", skip_serializing_if = "Option::is_none")]
+        min_size: Option<f64>,
+    },
     #[serde(rename = "UNSUBSCRIBE_WHALES")]
     UnsubscribeWhales,
 }
@@ -2980,9 +2983,9 @@ pub struct WebSocketEvent {
     /// Event-specific payload.
     #[serde(default)]
     pub data: serde_json::Value,
-    /// Unix millisecond timestamp when provided by the gateway.
+    /// Gateway timestamp when provided, preserved as numeric or string JSON.
     #[serde(default)]
-    pub timestamp: Option<u64>,
+    pub timestamp: Option<serde_json::Value>,
     /// Additional gateway fields preserved for forward compatibility.
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,


### PR DESCRIPTION
## Summary
- Adds WebSocket gateway client support for `/ws` with authenticated sessions.
- Adds `connect_websocket()` and `connect_websocket_with_auth_mode()` on `PolyforgeClient`, defaulting to cookie auth and allowing query-token auth.
- Adds subscribe/unsubscribe helpers for prices, whale-trades, and strategy broadcasts with basic request validation.
- Adds event message types/enums and a low-level websocket client wrapper over `tokio-tungstenite`.
- Exposes websocket APIs in `lib.rs` and documents usage in README.

## Tests
- `cargo test websocket --lib` (4 passed)
- `cargo test --lib` (429 passed)

Closes #308

## Review
Route this PR to Argus for approval.
