### PR TITLE
fix: type support ticket status

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -9603,11 +9603,26 @@ mod tests {
 
     #[test]
     fn test_ticket_deserializes() {
-        let json = r#"{"id":"t-1","subject":"Login issue","status":"open","createdAt":"2026-04-01","messages":[]}"#;
+        let json = r#"{"id":"t-1","subject":"Login issue","status":"OPEN","createdAt":"2026-04-01","messages":[]}"#;
         let t: Ticket = serde_json::from_str(json).unwrap();
         assert_eq!(t.id, "t-1");
-        assert_eq!(t.status.as_deref(), Some("open"));
+        assert_eq!(t.status, Some(TicketStatus::Open));
         assert!(t.messages.is_empty());
+    }
+
+    #[test]
+    fn test_ticket_status_enum_deserializes_all_variants() {
+        for (raw, expected) in [
+            ("OPEN", TicketStatus::Open),
+            ("AWAITING_USER", TicketStatus::AwaitingUser),
+            ("AWAITING_ADMIN", TicketStatus::AwaitingAdmin),
+            ("CLOSED", TicketStatus::Closed),
+        ] {
+            let json = format!("\"{}\"", raw);
+            let status: TicketStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(status, expected);
+            assert_eq!(serde_json::to_value(status).unwrap(), raw);
+        }
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -3709,6 +3709,18 @@ pub enum TicketPriority {
     Urgent,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TicketStatus {
+    #[serde(rename = "OPEN")]
+    Open,
+    #[serde(rename = "AWAITING_USER")]
+    AwaitingUser,
+    #[serde(rename = "AWAITING_ADMIN")]
+    AwaitingAdmin,
+    #[serde(rename = "CLOSED")]
+    Closed,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateTicketParams {
     pub subject: String,
@@ -3728,7 +3740,7 @@ pub struct Ticket {
     #[serde(default)]
     pub body: Option<String>,
     #[serde(default)]
-    pub status: Option<String>,
+    pub status: Option<TicketStatus>,
     #[serde(default)]
     pub category: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
## Summary
- Add `TicketStatus` enum for platform ticket statuses: `OPEN`, `AWAITING_USER`, `AWAITING_ADMIN`, `CLOSED`
- Change `Ticket.status` from `Option<String>` to `Option<TicketStatus>`
- Add regression coverage for ticket status deserialization/serialization

## Verification
- `cargo test ticket -- --nocapture`
- `cargo fmt --check`
- `cargo test`
- `npx gitnexus detect-changes --repo polyforge-sdk-rust --branch POLA-13919-polyforge-sdk-rust-300-compat-sdk-rust-ticket-status-is-option-lt-string-gt-no-ticketstatus-enum-even-though-` reported LOW risk, 0 affected processes

Closes #300