### PR TITLE
feat: add strategy capability discovery endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   - `idempotency_key_header()` validation tightened from non-empty to 8–128 characters.
 - **Auth behavior for public endpoints** — `get_actions()` now uses `get_with_optional_auth()` and `get_health()` uses `get_no_auth()` (never attaches the `Authorization` header). When the client is constructed with an empty API key these methods skip auth, matching the platform's public-route contract. `get_user_score()`, `get_user_badges()`, and `get_user_profile()` use `get()` which always sends the `Authorization: Bearer <key>` header, matching the platform requirement that these endpoints are authenticated (not public).
 - **Cross-SDK naming aliases** — `get_notifications()` is now a deprecated alias for `list_notifications()`, and `ReferralsInfo` is now a deprecated alias for the canonical `MyReferralsResponse` type.
+- **search_markets return type** — `search_markets()` now returns `MarketSearchResponse` (a flat `{ results: [...] }` envelope) instead of `PaginatedResponse<Market>`, matching the platform's actual response shape for `GET /api/v1/markets/search`. New `MarketSearchResponse` type. (POLA-5122)
+- **vote_market_sentiment params** — `vote_market_sentiment()` now accepts `VoteMarketSentimentParams` with `direction` and `confidence` fields instead of sending an empty JSON body, matching the platform's expected request schema for `POST /api/v1/markets/:marketId/sentiment`. (POLA-5122)
+
+### Fixed
+- **ConditionalOrder type alias** — `ConditionalOrder.condition_type` now accepts `"type"` as a serde alias, matching the platform's actual field name in `GET /api/v1/conditional-orders` responses. (POLA-5122)
 
 ### Added
 - **GDPR personal data export (POLA-3846)** — `export_personal_data()` and `export_personal_data_csv()` wrap `GET /api/v1/me/export` for GDPR-mandated right-to-export compliance. The JSON path returns a typed [`PersonalDataExport`] struct with `account`, `settings`, `security`, `trading`, `communications`, and `social` sections plus `_meta` truncation metadata; the CSV path returns plain text with `section, index, data_json` columns. Both paths send the `Content-Disposition: attachment` response and require a READ-scoped API key. (closes #215)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **ConditionalOrder type alias** — `ConditionalOrder.condition_type` now accepts `"type"` as a serde alias, matching the platform's actual field name in `GET /api/v1/conditional-orders` responses. (POLA-5122)
 
 ### Added
+- **Strategy capability discovery endpoints** — add `get_strategy_capabilities()`, `get_strategy_design_patterns()`, and `get_strategy_examples()` for AI/tooling discovery of supported strategy blocks, design patterns, and example strategy definitions. New types: `StrategyCapability`, `StrategyCapabilities`, `StrategyDesignPattern`, `StrategyDesignPatterns`, `StrategyExample`, and `StrategyExamples`. (closes #305)
 - **GDPR personal data export (POLA-3846)** — `export_personal_data()` and `export_personal_data_csv()` wrap `GET /api/v1/me/export` for GDPR-mandated right-to-export compliance. The JSON path returns a typed [`PersonalDataExport`] struct with `account`, `settings`, `security`, `trading`, `communications`, and `social` sections plus `_meta` truncation metadata; the CSV path returns plain text with `section, index, data_json` columns. Both paths send the `Content-Disposition: attachment` response and require a READ-scoped API key. (closes #215)
 - New types: `PersonalDataExport`, `PersonalDataExportMeta`.
 - **Sports markets API** — 9 new `PolyforgeClient` methods wrapping the `/api/v1/sports/*` endpoints (POLA-1841):

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ async fn main() -> polyforge::Result<()> {
 | `start_strategy(id, mode)` | Start a strategy (live or paper) |
 | `stop_strategy(id)` | Stop a running strategy |
 | `get_strategy_templates()` | List available templates |
+| `get_strategy_capabilities()` | Discover server-supported strategy builder capabilities |
+| `get_strategy_design_patterns()` | Discover strategy design pattern guidance |
+| `get_strategy_examples()` | Fetch example strategy definitions for tooling |
 | `export_strategy(id)` | Export strategy config as JSON |
 | `watch_strategy(id)` | Stream live execution events via SSE |
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -875,10 +875,11 @@ impl PolyforgeClient {
     }
 
     /// Full-text search across all markets.
+    /// Returns a flat `results` list (not a paginated envelope).
     pub async fn search_markets(
         &self,
         params: &SearchMarketsParams,
-    ) -> Result<PaginatedResponse<Market>> {
+    ) -> Result<MarketSearchResponse> {
         let mut qp: Vec<(&str, String)> = vec![("q", params.q.clone())];
         if let Some(l) = params.limit {
             qp.push(("limit", l.to_string()));
@@ -3778,10 +3779,14 @@ impl PolyforgeClient {
     /// (`POST /api/v1/markets/:marketId/sentiment`).
     ///
     /// Server returns the same sentiment report shape as the GET variant.
-    pub async fn vote_market_sentiment(&self, market_id: &str) -> Result<MarketSentimentReport> {
+    pub async fn vote_market_sentiment(
+        &self,
+        market_id: &str,
+        params: &VoteMarketSentimentParams,
+    ) -> Result<MarketSentimentReport> {
         self.post(
             &format!("/api/v1/markets/{}/sentiment", encode(market_id)),
-            &json!({}),
+            &serde_json::to_value(params)?,
         )
         .await
     }
@@ -6262,12 +6267,42 @@ mod tests {
     }
 
     #[test]
+    fn test_conditional_order_deserializes_type_field() {
+        // #250: Platform returns 'type' not 'conditionType' for condition_type
+        let json = r#"{
+            "id": "co-3",
+            "tokenId": "tok-xyz",
+            "side": "SELL",
+            "outcome": "NO",
+            "size": "200",
+            "triggerPrice": "0.80",
+            "limitPrice": "0.78",
+            "type": "STOP_LOSS",
+            "status": "PENDING",
+            "createdAt": "2026-05-01T10:00:00Z",
+            "triggeredAt": null,
+            "expiresAt": "2026-05-10T10:00:00Z"
+        }"#;
+        let co: ConditionalOrder = serde_json::from_str(json).unwrap();
+        assert_eq!(co.id, "co-3");
+        assert_eq!(co.condition_type.as_deref(), Some("STOP_LOSS"));
+        assert_eq!(co.status, Some(ConditionalOrderStatus::Pending));
+        assert_eq!(co.limit_price.as_deref(), Some("0.78"));
+        assert_eq!(co.trigger_price.as_deref(), Some("0.80"));
+    }
+
+    #[test]
     fn test_conditional_order_deserializes_minimal() {
         let json = r#"{"id": "co-2"}"#;
         let co: ConditionalOrder = serde_json::from_str(json).unwrap();
         assert_eq!(co.id, "co-2");
         assert!(co.token_id.is_none());
         assert!(co.status.is_none());
+    }
+
+    #[test]
+    fn test_smoke() {
+        let _client = PolyforgeClient::new("test-api-key").unwrap();
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1048,6 +1048,21 @@ impl PolyforgeClient {
         self.get("/api/v1/strategies/templates").await
     }
 
+    /// Fetch available strategy block capabilities for AI/tooling discovery.
+    pub async fn get_strategy_capabilities(&self) -> Result<StrategyCapabilities> {
+        self.get("/api/v1/strategies/capabilities").await
+    }
+
+    /// Fetch platform-authored strategy design patterns for AI/tooling discovery.
+    pub async fn get_strategy_design_patterns(&self) -> Result<StrategyDesignPatterns> {
+        self.get("/api/v1/strategies/design-patterns").await
+    }
+
+    /// Fetch example strategy definitions for AI/tooling discovery.
+    pub async fn get_strategy_examples(&self) -> Result<StrategyExamples> {
+        self.get("/api/v1/strategies/examples").await
+    }
+
     /// Export a strategy configuration as JSON.
     pub async fn export_strategy(&self, id: &str) -> Result<serde_json::Value> {
         self.get(&format!("/api/v1/strategies/{}/export", encode(id)))
@@ -6614,6 +6629,102 @@ mod tests {
         assert_eq!(tmpl.name, Some("Mean Reversion".to_string()));
         assert_eq!(tmpl.blocks.len(), 1);
         assert_eq!(tmpl.popularity, 342);
+    }
+
+    #[tokio::test]
+    async fn test_get_strategy_capabilities_path() {
+        let request = capture_request(
+            r#"{"version":"1.0","capabilities":{"triggers":[{"type":"PRICE_ABOVE"}]}}"#,
+            |client| async move { client.get_strategy_capabilities().await.map(|_| ()) },
+        )
+        .await;
+
+        assert!(request.contains("GET /api/v1/strategies/capabilities HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn test_get_strategy_design_patterns_path() {
+        let request = capture_request(
+            r#"{"version":"1.0","patterns":[{"name":"Mean reversion"}]}"#,
+            |client| async move { client.get_strategy_design_patterns().await.map(|_| ()) },
+        )
+        .await;
+
+        assert!(request.contains("GET /api/v1/strategies/design-patterns HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn test_get_strategy_examples_path() {
+        let request = capture_request(
+            r#"{"version":"1.0","examples":[{"name":"BTC momentum","strategy":{"name":"BTC momentum"}}]}"#,
+            |client| async move { client.get_strategy_examples().await.map(|_| ()) },
+        )
+        .await;
+
+        assert!(request.contains("GET /api/v1/strategies/examples HTTP/1.1"));
+    }
+
+    #[test]
+    fn test_strategy_capability_discovery_deserializes() {
+        let capabilities_json = r#"{
+            "version": "1.0",
+            "capabilities": {
+                "triggers": [
+                    {
+                        "type": "PRICE_ABOVE",
+                        "label": "Price above",
+                        "category": "triggers",
+                        "configSchema": {"threshold": {"type": "number"}},
+                        "examples": [{"threshold": 0.75}]
+                    }
+                ]
+            },
+            "generatedAt": "2026-06-29T00:00:00Z"
+        }"#;
+        let capabilities: StrategyCapabilities = serde_json::from_str(capabilities_json).unwrap();
+        assert_eq!(capabilities.version.as_deref(), Some("1.0"));
+        assert_eq!(
+            capabilities.capabilities["triggers"][0].capability_type,
+            "PRICE_ABOVE"
+        );
+        assert_eq!(
+            capabilities.capabilities["triggers"][0].category.as_deref(),
+            Some("triggers")
+        );
+        assert!(capabilities.extra.get("generatedAt").is_some());
+
+        let patterns_json = r#"{
+            "version": "1.0",
+            "patterns": [
+                {
+                    "name": "Mean reversion",
+                    "useCases": ["range-bound markets"],
+                    "blocks": {"triggers": ["PRICE_BELOW"]}
+                }
+            ]
+        }"#;
+        let patterns: StrategyDesignPatterns = serde_json::from_str(patterns_json).unwrap();
+        assert_eq!(patterns.patterns[0].name, "Mean reversion");
+        assert_eq!(
+            patterns.patterns[0].use_cases.as_ref().unwrap()[0],
+            "range-bound markets"
+        );
+
+        let examples_json = r#"{
+            "version": "1.0",
+            "examples": [
+                {
+                    "name": "BTC momentum",
+                    "strategy": {"name": "BTC momentum", "visibility": "PUBLIC"}
+                }
+            ]
+        }"#;
+        let examples: StrategyExamples = serde_json::from_str(examples_json).unwrap();
+        assert_eq!(examples.examples[0].name, "BTC momentum");
+        assert_eq!(
+            examples.examples[0].strategy.as_ref().unwrap()["name"],
+            "BTC momentum"
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -336,6 +336,92 @@ pub struct StrategyTemplate {
     pub extra: serde_json::Value,
 }
 
+/// A single server-supported strategy block capability.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyCapability {
+    #[serde(rename = "type")]
+    pub capability_type: String,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub category: Option<String>,
+    #[serde(default)]
+    pub config_schema: Option<serde_json::Value>,
+    #[serde(default)]
+    pub examples: Vec<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Strategy capability manifest for AI/tooling discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyCapabilities {
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub capabilities: std::collections::HashMap<String, Vec<StrategyCapability>>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// A platform-authored strategy design pattern.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyDesignPattern {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub use_cases: Option<Vec<String>>,
+    #[serde(default)]
+    pub blocks: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Strategy design pattern manifest for AI/tooling discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyDesignPatterns {
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub patterns: Vec<StrategyDesignPattern>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// An example strategy definition published for AI/tooling discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyExample {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub strategy: Option<serde_json::Value>,
+    #[serde(default)]
+    pub blocks: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+/// Strategy examples manifest for AI/tooling discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StrategyExamples {
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub examples: Vec<StrategyExample>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
 /// Parameters for creating a strategy with full block configuration.
 ///
 /// All fields except `name` are `Option` and default to `None`.

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,6 +61,13 @@ pub struct Token {
     pub price: Option<f64>,
 }
 
+/// Response from `GET /api/v1/markets/search` (flat `results` list, not paginated).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketSearchResponse {
+    pub results: Vec<Market>,
+}
+
 // ---------------------------------------------------------------------------
 // GDPR Personal Data Export (POLA-3846)
 // ---------------------------------------------------------------------------
@@ -1389,7 +1396,7 @@ pub struct ConditionalOrder {
     pub trigger_price: Option<String>,
     #[serde(default)]
     pub limit_price: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "type")]
     pub condition_type: Option<String>,
     #[serde(default)]
     pub status: Option<ConditionalOrderStatus>,
@@ -3823,6 +3830,14 @@ impl MarketHistoryPeriod {
 pub struct MarketSentimentVote {
     pub direction: String,
     pub confidence: f64,
+}
+
+/// Request body for `POST /api/v1/markets/:marketId/sentiment`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoteMarketSentimentParams {
+    pub direction: String,
+    pub confidence: i32,
 }
 
 /// Aggregated, market-controller-derived sentiment report.


### PR DESCRIPTION
## Summary
- Add Rust SDK methods for strategy capability discovery endpoints
- Add typed response models with extra field preservation for forward compatibility
- Document the new methods in README and CHANGELOG

## Test Plan
- cargo fmt --check
- cargo test get_strategy_ -- --nocapture
- cargo test strategy_capability -- --nocapture
- cargo test
- cargo clippy --all-targets -- -D warnings

Closes #305