### PR TITLE
feat: add strategy capability discovery endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@
 - **Strategy health endpoint (POLA-9105 / #301)** — add `get_strategy_health(id)` for
   `GET /api/v1/strategies/{id}/health`, returning the new typed
   `StrategyHealth` metrics payload.
+- **Strategy capability discovery (POLA-14718)** — `get_strategy_capabilities()`,
+  `get_strategy_design_patterns()`, and `get_strategy_examples()` wrap
+  `GET /api/v1/strategies/capabilities`,
+  `GET /api/v1/strategies/design-patterns`, and
+  `GET /api/v1/strategies/examples` for strategy-generation tooling. Adds
+  typed manifest structs: `StrategyCapabilities`, `StrategyCapability`,
+  `StrategyDesignPatterns`, `StrategyDesignPattern`, `StrategyExamples`, and
+  `StrategyExample`. (closes #305)
 - **GDPR personal data export (POLA-3846)** — `export_personal_data()` and `export_personal_data_csv()` wrap `GET /api/v1/me/export` for GDPR-mandated right-to-export compliance. The JSON path returns a typed [`PersonalDataExport`] struct with `account`, `settings`, `security`, `trading`, `communications`, and `social` sections plus `_meta` truncation metadata; the CSV path returns plain text with `section, index, data_json` columns. Both paths send the `Content-Disposition: attachment` response and require a READ-scoped API key. (closes #215)
 - New types: `PersonalDataExport`, `PersonalDataExportMeta`.
 - **Sports markets API** — 9 new `PolyforgeClient` methods wrapping the `/api/v1/sports/*` endpoints (POLA-1841):

--- a/README.md
+++ b/README.md
@@ -90,9 +90,12 @@ async fn main() -> polyforge::Result<()> {
 | `stop_strategy(id)` | Stop a running strategy |
 | `list_strategy_templates(params)` | List available templates with pagination |
 | `get_strategy_templates()` | List the first page of available templates |
-| `get_strategy_capabilities()` | Fetch the strategy builder capability manifest |
-| `get_strategy_design_patterns()` | Fetch strategy composition patterns |
-| `get_strategy_examples()` | Fetch example strategies for discovery and onboarding |
+| `get_strategy_capabilities()` | Fetch the raw strategy builder capability manifest |
+| `get_strategy_design_patterns()` | Fetch raw strategy composition patterns |
+| `get_strategy_examples()` | Fetch raw example strategies for discovery and onboarding |
+| `get_strategy_capabilities_typed()` | Discover typed server-supported strategy builder capabilities |
+| `get_strategy_design_patterns_typed()` | Discover typed strategy design pattern guidance |
+| `get_strategy_examples_typed()` | Fetch typed example strategy definitions for tooling |
 | `export_strategy(id)` | Export strategy config as JSON |
 | `watch_strategy(id)` | Stream live execution events via SSE |
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -10341,6 +10341,10 @@ mod tests {
             description: None,
             extra: serde_json::Value::Null,
         };
+
+        let serialized = serde_json::to_value(&_literal).unwrap();
+        assert_eq!(serialized["name"], "PRICE_BELOW");
+        assert!(serialized.get("type").is_none());
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -10272,6 +10272,138 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Strategy capability discovery — type and path tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_strategy_capabilities_deserializes() {
+        let json = r#"{
+            "version":"1.0",
+            "capabilities":{
+                "triggers":[{
+                    "type":"PRICE_ABOVE",
+                    "label":"Price above",
+                    "category":"triggers",
+                    "configSchema":{"threshold":{"type":"number"}},
+                    "serverOnly":true
+                }]
+            },
+            "generatedAt":"2026-07-01T00:00:00Z"
+        }"#;
+        let manifest: StrategyCapabilities = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.version.as_deref(), Some("1.0"));
+        let triggers = manifest.capabilities.get("triggers").unwrap();
+        assert_eq!(triggers[0].capability_type, "PRICE_ABOVE");
+        assert_eq!(
+            triggers[0].config_schema.as_ref().unwrap()["threshold"]["type"],
+            "number"
+        );
+        assert_eq!(triggers[0].extra["serverOnly"], true);
+        assert_eq!(manifest.extra["generatedAt"], "2026-07-01T00:00:00Z");
+    }
+
+    #[test]
+    fn test_strategy_design_patterns_deserializes() {
+        let json = r#"{
+            "version":"1.0",
+            "patterns":[{
+                "name":"Mean reversion",
+                "useCases":["range-bound markets"],
+                "blocks":{"triggers":["PRICE_BELOW"]},
+                "relatedTools":["create_strategy"]
+            }]
+        }"#;
+        let manifest: StrategyDesignPatterns = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.patterns[0].name, "Mean reversion");
+        assert_eq!(
+            manifest.patterns[0].use_cases.as_deref(),
+            Some(&["range-bound markets".to_string()] as &[String])
+        );
+        assert_eq!(
+            manifest.patterns[0].blocks.as_ref().unwrap()["triggers"][0],
+            "PRICE_BELOW"
+        );
+        assert_eq!(
+            manifest.patterns[0].extra["relatedTools"][0],
+            "create_strategy"
+        );
+    }
+
+    #[test]
+    fn test_strategy_examples_deserializes() {
+        let json = r#"{
+            "version":"1.0",
+            "examples":[{
+                "name":"BTC momentum",
+                "strategy":{"name":"BTC momentum","visibility":"PUBLIC"},
+                "nextTools":["create_strategy"]
+            }]
+        }"#;
+        let manifest: StrategyExamples = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.examples[0].name, "BTC momentum");
+        assert_eq!(
+            manifest.examples[0].strategy.as_ref().unwrap()["visibility"],
+            "PUBLIC"
+        );
+        assert_eq!(
+            manifest.examples[0].extra["nextTools"][0],
+            "create_strategy"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_strategy_capabilities_path_and_auth() {
+        let request = capture_request(
+            r#"{"version":"1.0","capabilities":{"triggers":[]}}"#,
+            |client| async move { client.get_strategy_capabilities().await.map(|_| ()) },
+        )
+        .await;
+        assert!(
+            request.contains("GET /api/v1/strategies/capabilities HTTP/1.1"),
+            "request must hit GET /api/v1/strategies/capabilities; got: {}",
+            request.lines().next().unwrap_or("")
+        );
+        assert_eq!(
+            captured_header(&request, "Authorization"),
+            Some("Bearer test-key")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_strategy_design_patterns_path_and_auth() {
+        let request = capture_request(r#"{"version":"1.0","patterns":[]}"#, |client| async move {
+            client.get_strategy_design_patterns().await.map(|_| ())
+        })
+        .await;
+        assert!(
+            request.contains("GET /api/v1/strategies/design-patterns HTTP/1.1"),
+            "request must hit GET /api/v1/strategies/design-patterns; got: {}",
+            request.lines().next().unwrap_or("")
+        );
+        assert_eq!(
+            captured_header(&request, "Authorization"),
+            Some("Bearer test-key")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_strategy_examples_path_and_auth() {
+        let request = capture_request(r#"{"version":"1.0","examples":[]}"#, |client| async move {
+            client.get_strategy_examples().await.map(|_| ())
+        })
+        .await;
+        assert!(
+            request.contains("GET /api/v1/strategies/examples HTTP/1.1"),
+            "request must hit GET /api/v1/strategies/examples; got: {}",
+            request.lines().next().unwrap_or("")
+        );
+        assert_eq!(
+            captured_header(&request, "Authorization"),
+            Some("Bearer test-key")
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // System Health — HTTP request-capture tests (POLA-3671)
     // -----------------------------------------------------------------------
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -10295,9 +10295,11 @@ mod tests {
         let triggers = manifest.capabilities.get("triggers").unwrap();
         assert_eq!(triggers[0].name, "PRICE_ABOVE");
         assert_eq!(
-            triggers[0].config_schema.as_ref().unwrap()["threshold"]["type"],
+            triggers[0].extra["configSchema"]["threshold"]["type"],
             "number"
         );
+        assert_eq!(triggers[0].extra["label"], "Price above");
+        assert_eq!(triggers[0].extra["category"], "triggers");
         assert_eq!(triggers[0].extra["serverOnly"], true);
         assert_eq!(manifest.extra["generatedAt"], "2026-07-01T00:00:00Z");
     }
@@ -10336,11 +10338,7 @@ mod tests {
         let _literal = StrategyCapability {
             name: "PRICE_BELOW".to_string(),
             version: None,
-            label: None,
             description: None,
-            category: None,
-            config_schema: None,
-            examples: None,
             extra: serde_json::Value::Null,
         };
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -10303,6 +10303,21 @@ mod tests {
     }
 
     #[test]
+    fn test_strategy_capabilities_accepts_legacy_name_field() {
+        let json = r#"{
+            "capabilities":{
+                "triggers":[{
+                    "name":"PRICE_ABOVE",
+                    "label":"Price above"
+                }]
+            }
+        }"#;
+        let manifest: StrategyCapabilities = serde_json::from_str(json).unwrap();
+        let triggers = manifest.capabilities.get("triggers").unwrap();
+        assert_eq!(triggers[0].capability_type, "PRICE_ABOVE");
+    }
+
+    #[test]
     fn test_strategy_design_patterns_deserializes() {
         let json = r#"{
             "version":"1.0",

--- a/src/client.rs
+++ b/src/client.rs
@@ -10293,7 +10293,7 @@ mod tests {
         let manifest: StrategyCapabilities = serde_json::from_str(json).unwrap();
         assert_eq!(manifest.version.as_deref(), Some("1.0"));
         let triggers = manifest.capabilities.get("triggers").unwrap();
-        assert_eq!(triggers[0].capability_type, "PRICE_ABOVE");
+        assert_eq!(triggers[0].name, "PRICE_ABOVE");
         assert_eq!(
             triggers[0].config_schema.as_ref().unwrap()["threshold"]["type"],
             "number"
@@ -10314,7 +10314,35 @@ mod tests {
         }"#;
         let manifest: StrategyCapabilities = serde_json::from_str(json).unwrap();
         let triggers = manifest.capabilities.get("triggers").unwrap();
-        assert_eq!(triggers[0].capability_type, "PRICE_ABOVE");
+        assert_eq!(triggers[0].name, "PRICE_ABOVE");
+    }
+
+    #[test]
+    fn test_strategy_capability_preserves_public_name_and_version_fields() {
+        let json = r#"{
+            "capabilities":{
+                "triggers":[{
+                    "type":"PRICE_ABOVE",
+                    "version":"2026-07-01",
+                    "label":"Price above"
+                }]
+            }
+        }"#;
+        let manifest: StrategyCapabilities = serde_json::from_str(json).unwrap();
+        let triggers = manifest.capabilities.get("triggers").unwrap();
+        assert_eq!(triggers[0].name, "PRICE_ABOVE");
+        assert_eq!(triggers[0].version.as_deref(), Some("2026-07-01"));
+
+        let _literal = StrategyCapability {
+            name: "PRICE_BELOW".to_string(),
+            version: None,
+            label: None,
+            description: None,
+            category: None,
+            config_schema: None,
+            examples: None,
+            extra: serde_json::Value::Null,
+        };
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -544,7 +544,7 @@ pub struct StrategyHealth {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StrategyCapability {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", alias = "name")]
     pub capability_type: String,
     #[serde(default)]
     pub label: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -547,17 +547,9 @@ pub struct StrategyCapability {
     #[serde(rename = "type", alias = "name")]
     pub name: String,
     #[serde(default)]
-    pub version: Option<String>,
-    #[serde(default)]
-    pub label: Option<String>,
-    #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
-    pub category: Option<String>,
-    #[serde(default)]
-    pub config_schema: Option<serde_json::Value>,
-    #[serde(default)]
-    pub examples: Option<Vec<serde_json::Value>>,
+    pub version: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -544,7 +544,7 @@ pub struct StrategyHealth {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StrategyCapability {
-    #[serde(rename = "type", alias = "name")]
+    #[serde(alias = "type")]
     pub name: String,
     #[serde(default)]
     pub description: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -540,18 +540,22 @@ pub struct StrategyHealth {
     pub last_updated: Option<String>,
 }
 
-/// A single capability entry returned by the strategy capabilities endpoint.
-///
-/// The platform groups capabilities by category; each category maps to a
-/// list of capability identifiers.
+/// A server-published strategy builder capability.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StrategyCapability {
-    pub name: String,
+    #[serde(rename = "type")]
+    pub capability_type: String,
+    #[serde(default)]
+    pub label: Option<String>,
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
-    pub version: Option<String>,
+    pub category: Option<String>,
+    #[serde(default)]
+    pub config_schema: Option<serde_json::Value>,
+    #[serde(default)]
+    pub examples: Option<Vec<serde_json::Value>>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -4681,8 +4685,6 @@ pub struct ActionsSchema {
     pub version: String,
     pub actions: Vec<ActionDefinition>,
 }
-
-// ---------------------------------------------------------------------------
 
 /// Aggregated correlation matrix between top market categories.
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -545,7 +545,9 @@ pub struct StrategyHealth {
 #[serde(rename_all = "camelCase")]
 pub struct StrategyCapability {
     #[serde(rename = "type", alias = "name")]
-    pub capability_type: String,
+    pub name: String,
+    #[serde(default)]
+    pub version: Option<String>,
     #[serde(default)]
     pub label: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
## Summary
- Add typed Rust SDK manifests for strategy capability discovery responses
- Add `get_strategy_capabilities`, `get_strategy_design_patterns`, and `get_strategy_examples` client methods
- Document the new strategy methods in README and CHANGELOG

Closes #305

## Verification
- `cargo fmt --check`
- `TMPDIR=$PWD/.cargo-tmp cargo test strategy_ --lib` (29 passed)
- `TMPDIR=$PWD/.cargo-tmp cargo test get_actions --lib` (2 passed)
- `TMPDIR=$PWD/.cargo-tmp cargo check`
- `npx gitnexus detect-changes --repo polyforge-sdk-rust --branch POLA-14718-polyforge-sdk-rust-305-support-strategy-capability-discovery-endpoints --scope all` (LOW risk, 0 affected processes)

Note: `graphify update .` could not run because the local `graphify` executable fails with `ModuleNotFoundError: No module named graphify`.
