### PR TITLE
fix: expose ticket message platform sender fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixed
 - **Webhook active alias** — `Webhook.enabled` now deserializes from platform `"active"` responses, matching the actual webhook payload shape while preserving the Rust SDK field name. (closes #306)
-- **TicketMessage response fields** — `TicketMessage` now exposes `sender_id`, `sender_name`, and `is_admin`, matching the platform's `senderId`, `senderName`, and `isAdmin` ticket-message response shape. (closes #313)
+- **TicketMessage response fields** — `TicketMessage` now maps platform `senderName` and `isAdmin` responses onto the existing `author` and `is_staff` fields, while preserving raw sender metadata in `extra`. (closes #313)
 - **list_smart_orders response type** — `list_smart_orders()` now returns `Vec<SmartOrder>` instead of `PaginatedResponse<SmartOrder>`, matching the bare array returned by `GET /api/v1/orders/smart`. (closes #303)
 - **search_markets response shape** — `search_markets()` now returns `SearchMarketsResponse { results: Vec<Market> }` instead of `PaginatedResponse<Market>`, matching the platform's actual `{ "results": [...] }` envelope. `MarketSearchResponse` is retained as a deprecated alias for backward compatibility. (#253)
 - **ConditionalOrder type alias** — `ConditionalOrder.condition_type` now accepts `"type"` as a serde alias, matching the platform's actual field name in `GET /api/v1/conditional-orders` responses. (POLA-5122)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - **Webhook active alias** — `Webhook.enabled` now deserializes from platform `"active"` responses, matching the actual webhook payload shape while preserving the Rust SDK field name. (closes #306)
+- **TicketMessage response fields** — `TicketMessage` now exposes `sender_id`, `sender_name`, and `is_admin`, matching the platform's `senderId`, `senderName`, and `isAdmin` ticket-message response shape. (closes #313)
 - **list_smart_orders response type** — `list_smart_orders()` now returns `Vec<SmartOrder>` instead of `PaginatedResponse<SmartOrder>`, matching the bare array returned by `GET /api/v1/orders/smart`. (closes #303)
 - **search_markets response shape** — `search_markets()` now returns `SearchMarketsResponse { results: Vec<Market> }` instead of `PaginatedResponse<Market>`, matching the platform's actual `{ "results": [...] }` envelope. `MarketSearchResponse` is retained as a deprecated alias for backward compatibility. (#253)
 - **ConditionalOrder type alias** — `ConditionalOrder.condition_type` now accepts `"type"` as a serde alias, matching the platform's actual field name in `GET /api/v1/conditional-orders` responses. (POLA-5122)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixed
 - **Webhook active alias** — `Webhook.enabled` now deserializes from platform `"active"` responses, matching the actual webhook payload shape while preserving the Rust SDK field name. (closes #306)
-- **TicketMessage response fields** — `TicketMessage` now maps platform `senderName` and `isAdmin` responses onto the existing `author` and `is_staff` fields, while preserving raw sender metadata in `extra`. (closes #313)
+- **TicketMessage response fields** — `TicketMessage` now preserves the public `sender_name` / `is_admin` aliases, mirrors those platform values onto the legacy `author` / `is_staff` fields for compatibility, and keeps raw sender metadata in `extra`. (closes #313)
 - **list_smart_orders response type** — `list_smart_orders()` now returns `Vec<SmartOrder>` instead of `PaginatedResponse<SmartOrder>`, matching the bare array returned by `GET /api/v1/orders/smart`. (closes #303)
 - **search_markets response shape** — `search_markets()` now returns `SearchMarketsResponse { results: Vec<Market> }` instead of `PaginatedResponse<Market>`, matching the platform's actual `{ "results": [...] }` envelope. `MarketSearchResponse` is retained as a deprecated alias for backward compatibility. (#253)
 - **ConditionalOrder type alias** — `ConditionalOrder.condition_type` now accepts `"type"` as a serde alias, matching the platform's actual field name in `GET /api/v1/conditional-orders` responses. (POLA-5122)

--- a/src/client.rs
+++ b/src/client.rs
@@ -10117,9 +10117,10 @@ mod tests {
 
     #[test]
     fn test_ticket_message_deserializes() {
-        let json = r#"{"id":"msg-1","ticketId":"t-1","body":"We are looking into it.","senderName":"support","isAdmin":true,"createdAt":"2026-04-02"}"#;
+        let json = r#"{"id":"msg-1","ticketId":"t-1","senderId":"user-1","body":"We are looking into it.","senderName":"support","isAdmin":true,"createdAt":"2026-04-02"}"#;
         let m: TicketMessage = serde_json::from_str(json).unwrap();
         assert_eq!(m.id, "msg-1");
+        assert_eq!(m.sender_id.as_deref(), Some("user-1"));
         assert_eq!(m.is_admin, Some(true));
         assert_eq!(m.sender_name.as_deref(), Some("support"));
         assert_eq!(m.is_staff, Some(true));

--- a/src/client.rs
+++ b/src/client.rs
@@ -7731,6 +7731,7 @@ mod tests {
         assert_eq!(co.condition_type.as_deref(), Some("TAKE_PROFIT"));
     }
 
+    #[test]
     fn test_create_conditional_order_params_serializes_camelcase() {
         let params = CreateConditionalOrderParams {
             market_id: "mkt-1".into(),
@@ -10120,42 +10121,49 @@ mod tests {
         let json = r#"{"id":"msg-1","ticketId":"t-1","senderId":"user-1","body":"We are looking into it.","senderName":"support","isAdmin":true,"createdAt":"2026-04-02"}"#;
         let m: TicketMessage = serde_json::from_str(json).unwrap();
         assert_eq!(m.id, "msg-1");
-        assert_eq!(m.sender_id.as_deref(), Some("user-1"));
-        assert_eq!(m.is_admin, Some(true));
-        assert_eq!(m.sender_name.as_deref(), Some("support"));
         assert_eq!(m.is_staff, Some(true));
         assert_eq!(m.author.as_deref(), Some("support"));
         assert_eq!(m.extra["senderName"], "support");
         assert_eq!(m.extra["isAdmin"], true);
+        assert_eq!(m.extra["senderId"], "user-1");
 
         let transition_json = r#"{"id":"msg-2","senderName":"support","author":"legacy","isAdmin":true,"isStaff":false}"#;
         let transition: TicketMessage = serde_json::from_str(transition_json).unwrap();
-        assert_eq!(transition.sender_name.as_deref(), Some("support"));
         assert_eq!(transition.author.as_deref(), Some("support"));
-        assert_eq!(transition.is_admin, Some(true));
         assert_eq!(transition.is_staff, Some(true));
-        let serialized_transition = serde_json::to_string(&transition).unwrap();
-        assert_eq!(serialized_transition.matches("senderName").count(), 1);
-        assert_eq!(serialized_transition.matches("isAdmin").count(), 1);
+        let serialized_transition: serde_json::Value = serde_json::to_value(&transition).unwrap();
+        assert_eq!(serialized_transition["author"], "support");
+        assert_eq!(serialized_transition["isStaff"], true);
+        assert!(serialized_transition.get("senderName").is_none());
+        assert!(serialized_transition.get("isAdmin").is_none());
 
         let null_json =
             r#"{"id":"msg-3","senderName":null,"author":"legacy","isAdmin":null,"isStaff":true}"#;
         let null_message: TicketMessage = serde_json::from_str(null_json).unwrap();
-        assert_eq!(null_message.sender_name, None);
         assert_eq!(null_message.author, None);
-        assert_eq!(null_message.is_admin, None);
         assert_eq!(null_message.is_staff, None);
         assert!(null_message.extra["senderName"].is_null());
         assert!(null_message.extra["isAdmin"].is_null());
 
         let legacy_json = r#"{"id":"msg-4","author":"legacy","isStaff":true}"#;
         let legacy_message: TicketMessage = serde_json::from_str(legacy_json).unwrap();
-        assert_eq!(legacy_message.sender_name.as_deref(), Some("legacy"));
         assert_eq!(legacy_message.author.as_deref(), Some("legacy"));
-        assert_eq!(legacy_message.is_admin, Some(true));
         assert_eq!(legacy_message.is_staff, Some(true));
         assert!(legacy_message.extra.get("senderName").is_none());
         assert!(legacy_message.extra.get("isAdmin").is_none());
+    }
+
+    #[test]
+    fn test_ticket_message_serializes_without_duplicate_sender_aliases() {
+        let json = r#"{"id":"msg-1","ticketId":"t-1","body":"We are looking into it.","senderName":"support","isAdmin":true,"senderId":"user-1","createdAt":"2026-04-02"}"#;
+        let m: TicketMessage = serde_json::from_str(json).unwrap();
+        let v = serde_json::to_value(&m).unwrap();
+
+        assert_eq!(v["author"], "support");
+        assert_eq!(v["isStaff"], true);
+        assert_eq!(v["senderId"], "user-1");
+        assert!(v.get("senderName").is_none());
+        assert!(v.get("isAdmin").is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/src/client.rs
+++ b/src/client.rs
@@ -10121,6 +10121,8 @@ mod tests {
         let json = r#"{"id":"msg-1","ticketId":"t-1","senderId":"user-1","body":"We are looking into it.","senderName":"support","isAdmin":true,"createdAt":"2026-04-02"}"#;
         let m: TicketMessage = serde_json::from_str(json).unwrap();
         assert_eq!(m.id, "msg-1");
+        assert_eq!(m.sender_name.as_deref(), Some("support"));
+        assert_eq!(m.is_admin, Some(true));
         assert_eq!(m.is_staff, Some(true));
         assert_eq!(m.author.as_deref(), Some("support"));
         assert_eq!(m.extra["senderName"], "support");
@@ -10129,17 +10131,21 @@ mod tests {
 
         let transition_json = r#"{"id":"msg-2","senderName":"support","author":"legacy","isAdmin":true,"isStaff":false}"#;
         let transition: TicketMessage = serde_json::from_str(transition_json).unwrap();
+        assert_eq!(transition.sender_name.as_deref(), Some("support"));
+        assert_eq!(transition.is_admin, Some(true));
         assert_eq!(transition.author.as_deref(), Some("support"));
         assert_eq!(transition.is_staff, Some(true));
         let serialized_transition: serde_json::Value = serde_json::to_value(&transition).unwrap();
+        assert_eq!(serialized_transition["senderName"], "support");
+        assert_eq!(serialized_transition["isAdmin"], true);
         assert_eq!(serialized_transition["author"], "support");
         assert_eq!(serialized_transition["isStaff"], true);
-        assert!(serialized_transition.get("senderName").is_none());
-        assert!(serialized_transition.get("isAdmin").is_none());
 
         let null_json =
             r#"{"id":"msg-3","senderName":null,"author":"legacy","isAdmin":null,"isStaff":true}"#;
         let null_message: TicketMessage = serde_json::from_str(null_json).unwrap();
+        assert_eq!(null_message.sender_name, None);
+        assert_eq!(null_message.is_admin, None);
         assert_eq!(null_message.author, None);
         assert_eq!(null_message.is_staff, None);
         assert!(null_message.extra["senderName"].is_null());
@@ -10147,6 +10153,8 @@ mod tests {
 
         let legacy_json = r#"{"id":"msg-4","author":"legacy","isStaff":true}"#;
         let legacy_message: TicketMessage = serde_json::from_str(legacy_json).unwrap();
+        assert_eq!(legacy_message.sender_name.as_deref(), Some("legacy"));
+        assert_eq!(legacy_message.is_admin, Some(true));
         assert_eq!(legacy_message.author.as_deref(), Some("legacy"));
         assert_eq!(legacy_message.is_staff, Some(true));
         assert!(legacy_message.extra.get("senderName").is_none());
@@ -10159,11 +10167,11 @@ mod tests {
         let m: TicketMessage = serde_json::from_str(json).unwrap();
         let v = serde_json::to_value(&m).unwrap();
 
+        assert_eq!(v["senderName"], "support");
+        assert_eq!(v["isAdmin"], true);
         assert_eq!(v["author"], "support");
         assert_eq!(v["isStaff"], true);
         assert_eq!(v["senderId"], "user-1");
-        assert!(v.get("senderName").is_none());
-        assert!(v.get("isAdmin").is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/src/types.rs
+++ b/src/types.rs
@@ -3837,6 +3837,8 @@ pub struct TicketMessage {
     pub id: String,
     pub ticket_id: Option<String>,
     pub body: Option<String>,
+    pub sender_name: Option<String>,
+    pub is_admin: Option<bool>,
     pub author: Option<String>,
     pub is_staff: Option<bool>,
     pub created_at: Option<String>,
@@ -3861,20 +3863,22 @@ impl<'de> Deserialize<'de> for TicketMessage {
             deserialize_ticket_message_field(&mut fields, "senderName")?;
         let legacy_author: Option<String> =
             deserialize_ticket_message_field(&mut fields, "author")?.0;
-        let author = if raw_sender_name.is_some() {
+        let sender_name = if raw_sender_name.is_some() {
             platform_sender_name
         } else {
             legacy_author
         };
+        let author = sender_name.clone();
         let (platform_is_admin, raw_is_admin): (Option<bool>, Option<serde_json::Value>) =
             deserialize_ticket_message_field(&mut fields, "isAdmin")?;
         let legacy_is_staff: Option<bool> =
             deserialize_ticket_message_field(&mut fields, "isStaff")?.0;
-        let is_staff = if raw_is_admin.is_some() {
+        let is_admin = if raw_is_admin.is_some() {
             platform_is_admin
         } else {
             legacy_is_staff
         };
+        let is_staff = is_admin;
         let created_at: Option<String> =
             deserialize_ticket_message_field(&mut fields, "createdAt")?.0;
 
@@ -3890,6 +3894,8 @@ impl<'de> Deserialize<'de> for TicketMessage {
             id,
             ticket_id,
             body,
+            sender_name,
+            is_admin,
             author,
             is_staff,
             created_at,
@@ -3905,7 +3911,7 @@ impl Serialize for TicketMessage {
     {
         use serde::ser::SerializeMap;
 
-        let mut field_count = 6;
+        let mut field_count = 8;
         if let serde_json::Value::Object(extra) = &self.extra {
             field_count += extra
                 .keys()
@@ -3914,11 +3920,11 @@ impl Serialize for TicketMessage {
                         key.as_str(),
                         "id" | "ticketId"
                             | "body"
+                            | "senderName"
+                            | "isAdmin"
                             | "author"
                             | "isStaff"
                             | "createdAt"
-                            | "senderName"
-                            | "isAdmin"
                     )
                 })
                 .count();
@@ -3928,6 +3934,8 @@ impl Serialize for TicketMessage {
         map.serialize_entry("id", &self.id)?;
         map.serialize_entry("ticketId", &self.ticket_id)?;
         map.serialize_entry("body", &self.body)?;
+        map.serialize_entry("senderName", &self.sender_name)?;
+        map.serialize_entry("isAdmin", &self.is_admin)?;
         map.serialize_entry("author", &self.author)?;
         map.serialize_entry("isStaff", &self.is_staff)?;
         map.serialize_entry("createdAt", &self.created_at)?;
@@ -3938,11 +3946,11 @@ impl Serialize for TicketMessage {
                     key.as_str(),
                     "id" | "ticketId"
                         | "body"
+                        | "senderName"
+                        | "isAdmin"
                         | "author"
                         | "isStaff"
                         | "createdAt"
-                        | "senderName"
-                        | "isAdmin"
                 ) {
                     map.serialize_entry(key, value)?;
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3836,6 +3836,7 @@ pub struct Ticket {
 pub struct TicketMessage {
     pub id: String,
     pub ticket_id: Option<String>,
+    pub sender_id: Option<String>,
     pub body: Option<String>,
     pub sender_name: Option<String>,
     pub is_admin: Option<bool>,
@@ -3858,6 +3859,8 @@ impl<'de> Deserialize<'de> for TicketMessage {
             .and_then(|value| serde_json::from_value(value).map_err(serde::de::Error::custom))?;
         let ticket_id: Option<String> =
             deserialize_ticket_message_field(&mut fields, "ticketId")?.0;
+        let sender_id: Option<String> =
+            deserialize_ticket_message_field(&mut fields, "senderId")?.0;
         let body: Option<String> = deserialize_ticket_message_field(&mut fields, "body")?.0;
         let (platform_sender_name, raw_sender_name): (Option<String>, Option<serde_json::Value>) =
             deserialize_ticket_message_field(&mut fields, "senderName")?;
@@ -3891,6 +3894,7 @@ impl<'de> Deserialize<'de> for TicketMessage {
         Ok(Self {
             id,
             ticket_id,
+            sender_id,
             body,
             author: sender_name.clone(),
             sender_name,
@@ -3909,7 +3913,7 @@ impl Serialize for TicketMessage {
     {
         use serde::ser::SerializeMap;
 
-        let mut field_count = 6;
+        let mut field_count = 7;
         if let serde_json::Value::Object(extra) = &self.extra {
             field_count += extra
                 .keys()
@@ -3920,6 +3924,7 @@ impl Serialize for TicketMessage {
         let mut map = serializer.serialize_map(Some(field_count))?;
         map.serialize_entry("id", &self.id)?;
         map.serialize_entry("ticketId", &self.ticket_id)?;
+        map.serialize_entry("senderId", &self.sender_id)?;
         map.serialize_entry("body", &self.body)?;
         map.serialize_entry("senderName", &self.sender_name)?;
         map.serialize_entry("isAdmin", &self.is_admin)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -3836,10 +3836,7 @@ pub struct Ticket {
 pub struct TicketMessage {
     pub id: String,
     pub ticket_id: Option<String>,
-    pub sender_id: Option<String>,
     pub body: Option<String>,
-    pub sender_name: Option<String>,
-    pub is_admin: Option<bool>,
     pub author: Option<String>,
     pub is_staff: Option<bool>,
     pub created_at: Option<String>,
@@ -3859,14 +3856,12 @@ impl<'de> Deserialize<'de> for TicketMessage {
             .and_then(|value| serde_json::from_value(value).map_err(serde::de::Error::custom))?;
         let ticket_id: Option<String> =
             deserialize_ticket_message_field(&mut fields, "ticketId")?.0;
-        let sender_id: Option<String> =
-            deserialize_ticket_message_field(&mut fields, "senderId")?.0;
         let body: Option<String> = deserialize_ticket_message_field(&mut fields, "body")?.0;
         let (platform_sender_name, raw_sender_name): (Option<String>, Option<serde_json::Value>) =
             deserialize_ticket_message_field(&mut fields, "senderName")?;
         let legacy_author: Option<String> =
             deserialize_ticket_message_field(&mut fields, "author")?.0;
-        let sender_name = if raw_sender_name.is_some() {
+        let author = if raw_sender_name.is_some() {
             platform_sender_name
         } else {
             legacy_author
@@ -3875,7 +3870,7 @@ impl<'de> Deserialize<'de> for TicketMessage {
             deserialize_ticket_message_field(&mut fields, "isAdmin")?;
         let legacy_is_staff: Option<bool> =
             deserialize_ticket_message_field(&mut fields, "isStaff")?.0;
-        let is_admin = if raw_is_admin.is_some() {
+        let is_staff = if raw_is_admin.is_some() {
             platform_is_admin
         } else {
             legacy_is_staff
@@ -3894,12 +3889,9 @@ impl<'de> Deserialize<'de> for TicketMessage {
         Ok(Self {
             id,
             ticket_id,
-            sender_id,
             body,
-            author: sender_name.clone(),
-            sender_name,
-            is_staff: is_admin,
-            is_admin,
+            author,
+            is_staff,
             created_at,
             extra: serde_json::Value::Object(extra),
         })
@@ -3913,26 +3905,45 @@ impl Serialize for TicketMessage {
     {
         use serde::ser::SerializeMap;
 
-        let mut field_count = 7;
+        let mut field_count = 6;
         if let serde_json::Value::Object(extra) = &self.extra {
             field_count += extra
                 .keys()
-                .filter(|key| key.as_str() != "senderName" && key.as_str() != "isAdmin")
+                .filter(|key| {
+                    !matches!(
+                        key.as_str(),
+                        "id" | "ticketId"
+                            | "body"
+                            | "author"
+                            | "isStaff"
+                            | "createdAt"
+                            | "senderName"
+                            | "isAdmin"
+                    )
+                })
                 .count();
         }
 
         let mut map = serializer.serialize_map(Some(field_count))?;
         map.serialize_entry("id", &self.id)?;
         map.serialize_entry("ticketId", &self.ticket_id)?;
-        map.serialize_entry("senderId", &self.sender_id)?;
         map.serialize_entry("body", &self.body)?;
-        map.serialize_entry("senderName", &self.sender_name)?;
-        map.serialize_entry("isAdmin", &self.is_admin)?;
+        map.serialize_entry("author", &self.author)?;
+        map.serialize_entry("isStaff", &self.is_staff)?;
         map.serialize_entry("createdAt", &self.created_at)?;
 
         if let serde_json::Value::Object(extra) = &self.extra {
             for (key, value) in extra {
-                if key != "senderName" && key != "isAdmin" {
+                if !matches!(
+                    key.as_str(),
+                    "id" | "ticketId"
+                        | "body"
+                        | "author"
+                        | "isStaff"
+                        | "createdAt"
+                        | "senderName"
+                        | "isAdmin"
+                ) {
                     map.serialize_entry(key, value)?;
                 }
             }


### PR DESCRIPTION
## Summary

- add typed `sender_id` handling for `TicketMessage` responses from platform `senderId`
- preserve current `senderName` / `isAdmin` typed fields and legacy `author` / `isStaff` compatibility behavior
- add regression coverage for platform-shaped ticket message payloads

Closes #313.

## Verification

- `cargo test test_ticket_message_deserializes`
- `cargo fmt --check`
- `git diff --check origin/master...HEAD`
- `gitleaks detect --redact --log-opts origin/master..HEAD`

## GitNexus

- `impact TicketMessage --direction upstream --repo /home/f4cte/polyforge-sdk-rust --include-tests --depth 4`: LOW risk, 0 direct callers, 0 affected processes, 0 affected modules
- `impact test_ticket_message_deserializes --direction upstream --repo /home/f4cte/polyforge-sdk-rust --include-tests --depth 4`: LOW risk, 0 direct callers, 0 affected processes, 0 affected modules
- `detect_changes --scope compare --base-ref origin/master --repo /home/f4cte/polyforge-sdk-rust` returned `No changes detected` despite the visible compare diff in this Paperclip worktree; fallback scope evidence is `git diff --name-status origin/master...HEAD` showing only `CHANGELOG.md`, `src/client.rs`, and `src/types.rs`.
