### PR TITLE
docs: update copyright owner and package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,12 @@
 name = "polyforge"
 version = "3.0.0"
 edition = "2021"
+authors = ["Oryon Technologies <dev@polyforge.app>"]
 license = "Apache-2.0"
 description = "Rust SDK for the Polyforge trading platform REST API"
+homepage = "https://polyforge.app"
+repository = "https://github.com/Polyforge-labs/PolyForge-sdk-rust"
+documentation = "https://docs.rs/polyforge"
 keywords = ["polyforge", "trading", "api", "sdk", "async"]
 categories = ["api-bindings", "web-programming::http-client"]
 

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 PolyForge Labs
+   Copyright 2026 Oryon Technologies
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 PolyForge SDK Rust
-Copyright 2026 PolyForge Labs
+Copyright 2026 Oryon Technologies
 
 Licensed under the Apache License, Version 2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# polyforge
+# PolyForge Rust SDK
 
-Async Rust SDK for the [Polyforge](https://polyforge.io) trading platform REST API.
+Async Rust SDK for the [PolyForge](https://polyforge.app) REST API, compatible with self-hosted and PolyForge Platform deployments.
 
 ## Installation
 
@@ -484,4 +484,6 @@ cargo test
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE) for details.
+Copyright © 2026 Oryon Technologies.
+
+Licensed under Apache 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE) for details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PolyForge Rust SDK
 
-Async Rust SDK for the [PolyForge](https://polyforge.app) REST API, compatible with self-hosted and PolyForge Platform deployments.
+Async Rust SDK for the [PolyForge](https://polyforge.app) REST API, compatible with PolyForge Platform and self-hosted deployments. Self-hosted endpoints must normally use HTTPS with a hostname that is not reserved for local networks; HTTP is accepted only for loopback development hosts, and private or reserved IP literals are rejected by the client's SSRF protections.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- update copyright ownership from PolyForge Labs to Oryon Technologies
- replace stale polyforge.io references and add current project metadata
- clarify compatibility with self-hosted PolyForge and PolyForge Platform deployments
- retain the existing Apache 2.0 SDK licence

## Verification

- `cargo test` — 528 unit tests plus integration and documentation tests passed
- `cargo clippy -- -D warnings`
- `cargo build`
- `git diff --check` passed
- GitNexus staged analysis: low risk, 0 affected execution flows